### PR TITLE
Use working_dir instead of cd in dynamodb_local process-compose

### DIFF
--- a/plugins/dynamodb_local/process-compose.yaml
+++ b/plugins/dynamodb_local/process-compose.yaml
@@ -2,9 +2,10 @@ version: "0.5"
 
 processes:
   dynamodb_local:
-    # `cd` so this command is run from a git ignored directory, because
-    # it creates a metadata file in the directory it starts in, and we
-    # want that to be hidden
-    command: cd {{ .Virtenv }} && dynamodb_local
+    # working_dir set so command is run from a git ignored directory. 
+    # dynamodb_local creates a metadata file in the directory it starts in, and we
+    # want that to be hidden.
+    working_dir: {{ .Virtenv }}
+    command: dynamodb_local
     availability:
       restart: on_failure


### PR DESCRIPTION
Option is documented here:
  https://f1bonacc1.github.io/process-compose/launcher/#specify-a-working-directory

I have not tested the change with this plugin but I have tested the option in another projects process-compose.yaml