### PR TITLE
adr-tools package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696323343,
-        "narHash": "sha256-u7WLUrh5eb+6SBYwtkaGL2ryHpLcHzmLml+a+VqKJWE=",
+        "lastModified": 1702921762,
+        "narHash": "sha256-O/rP7gulApQAB47u6szEd8Pn8Biw0d84j5iuP2tcxzY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3b79cc4bcd9c09b5aa68ea1957c25e437dc6bc58",
+        "rev": "d02ffbbe834b5599fc5f134e644e49397eb07188",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "type": "indirect"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702921762,
-        "narHash": "sha256-O/rP7gulApQAB47u6szEd8Pn8Biw0d84j5iuP2tcxzY=",
+        "lastModified": 1703013332,
+        "narHash": "sha256-+tFNwMvlXLbJZXiMHqYq77z/RfmpfpiI3yjL6o/Zo9M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d02ffbbe834b5599fc5f134e644e49397eb07188",
+        "rev": "54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-23.11",
+        "ref": "nixos-unstable",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     # this flake only works for darwin binaries (for now)
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = nixpkgs.legacyPackages."${system}";
+        pkgs = import nixpkgs { system = "${system}"; config.allowUnfree = true;};
         mongodb-4_4 = pkgs.callPackage ./packages/mongodb-4_4.nix { };
         dynamodb_local = pkgs.callPackage ./packages/dynamodb_local.nix { };
         adr-tools = pkgs.callPackage ./packages/adr-tools.nix {};

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "mongodb packaged from the official binaries to avoid compilation";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-23.11";
+    nixpkgs.url = "nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "mongodb packaged from the official binaries to avoid compilation";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-23.05";
+    nixpkgs.url = "nixpkgs/nixos-23.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -13,8 +13,9 @@
         pkgs = nixpkgs.legacyPackages."${system}";
         mongodb-4_4 = pkgs.callPackage ./packages/mongodb-4_4.nix { };
         dynamodb_local = pkgs.callPackage ./packages/dynamodb_local.nix { };
+        adr-tools = pkgs.callPackage ./packages/adr-tools.nix {};
       in
       {
-        packages = { inherit mongodb-4_4 dynamodb_local; };
+        packages = { inherit mongodb-4_4 dynamodb_local adr-tools; };
       });
 }

--- a/packages/adr-tools.nix
+++ b/packages/adr-tools.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, fetchFromGitHub, getopt, bashInteractive }:
+let 
+  inherit (lib) licenses maintainers platforms;
+  in 
+stdenv.mkDerivation rec {
+  name = "adr-tools-${version}";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "npryce";
+    repo = "adr-tools";
+    rev = "${version}";
+    sha256 = "1igssl6853wagi5050157bbmr9j12703fqfm8cd7gscqwjghnk14";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile --replace '/bin:/usr/bin' '$(PATH)'
+  '';
+
+  propagatedBuildInputs = [ getopt bashInteractive ];
+
+  buildPhase = ''
+    patchShebangs src/
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    make check
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin/
+    cp src/* $out/bin/
+  '';
+
+  meta = {
+    homepage = https://github.com/npryce/adr-tools;
+    description = "Command-line tools for working with Architecture Decision Records";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.aepsil0n ];
+    platforms = platforms.darwin;
+  };
+}

--- a/packages/adr-tools.nix
+++ b/packages/adr-tools.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, getopt, bashInteractive }:
-let 
-  inherit (lib) licenses maintainers platforms;
-  in 
+let
+  inherit (lib) licenses;
+in
 stdenv.mkDerivation rec {
   name = "adr-tools-${version}";
   version = "3.0.0";
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = https://github.com/npryce/adr-tools;
+    homepage = "https://github.com/npryce/adr-tools";
     description = "Command-line tools for working with Architecture Decision Records";
     license = licenses.gpl3;
   };

--- a/packages/adr-tools.nix
+++ b/packages/adr-tools.nix
@@ -38,7 +38,5 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/npryce/adr-tools;
     description = "Command-line tools for working with Architecture Decision Records";
     license = licenses.gpl3;
-    maintainers = [ maintainers.aepsil0n ];
-    platforms = platforms.darwin;
   };
 }


### PR DESCRIPTION
Including in this PR:

- adr-tools Nix package
- change Nixpkgs from `nixos-23.05` to `nixos-unstable`
- allow unfree Nixpkgs packages 

Reference:
- https://cultureamp.atlassian.net/browse/FEF-881
- [adr-tools: init at 3.0.0 by milibopp · Pull Request #57901 · NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/pull/57901) 
- [adr-tools](https://github.com/npryce/adr-tools)