### PR TITLE
Add corepack plugin

### DIFF
--- a/plugins/corepack/README.md
+++ b/plugins/corepack/README.md
@@ -1,0 +1,55 @@
+# Corepack plugin
+
+This plugin sets up [Corepack](https://github.com/nodejs/corepack/), a NodeJS feature to automatically install the correct version of Yarn or PNPM.
+
+When using corepack, running `pnpm` or `yarn` will always use the correct version as defined in the `packageManager` field of the project's `package.json` file.
+
+## Use and activation
+
+1. Add this plugin to the `include` section of your `devbox.json`:
+
+```json
+{
+  "include": ["github:cultureamp/devbox-extras?dir=plugins/corepack"]
+}
+```
+
+2. Ensure your `package.json` sets the `packageManager` field:
+
+```json
+{
+  "packageManager": "pnpm@8.15.3"
+}
+```
+
+or
+
+```json
+{
+  "packageManager": "yarn@1.22.21"
+}
+```
+
+## Motivation
+
+There’s a subtle but messy issue that can arise using Devbox, Node.js, and Yarn/PNPM. If you install node and yarn as documented you will end up with two different versions of node:
+
+```sh
+$ devbox add nodejs@20.8 yarn
+...
+$ devbox run node --version
+v20.8.0
+$ devbox run yarn node --version
+yarn node v1.22.19
+v18.18.0
+```
+
+This happens because nix bundles all dependencies into every package, yarn is getting it’s own copy of Node.js, which may be more recent than the Node.js version the project is using.
+
+Corepack by default tries to install shim scripts for both `yarn` and `pnpm` in the same directory that `node` is found in. Unfortunately when using devbox, the `node` binary is in the Nix store, which is read only, so Corepack fails to set up correctly.
+
+This plugin works by:
+
+- creating a folder in `.devbox/virtenv/pnpm_plugin/bin/`
+- running `corepack enable --install-directory "./devbox/virtenv/pnpm_plugin/bin/"`, which adds the `pnpm` and `yarn` shim scripts
+- and then adding `./devbox/virtenv/pnpm_plugin/bin/` to the `PATH` environment variable.

--- a/plugins/corepack/README.md
+++ b/plugins/corepack/README.md
@@ -6,15 +6,24 @@ When using corepack, running `pnpm` or `yarn` will always use the correct versio
 
 ## Use and activation
 
+1. Make sure you already have a `nodejs` listed as one of your packages in `devbox.json`. You don't need to list `pnpm` or `yarn`:
+
+```json
+{
+  "packages": ["nodejs@18.19.1"]
+}
+```
+
 1. Add this plugin to the `include` section of your `devbox.json`:
 
 ```json
 {
+  "packages": ["nodejs@18.19.1"],
   "include": ["github:cultureamp/devbox-extras?dir=plugins/corepack"]
 }
 ```
 
-2. Ensure your `package.json` sets the `packageManager` field:
+2. Ensure your `package.json` sets a `packageManager` field, for example:
 
 ```json
 {
@@ -29,6 +38,8 @@ or
   "packageManager": "yarn@1.22.21"
 }
 ```
+
+When you run `pnpm -v` or `yarn -v` you should see that the versions used match what you've set in the `packageManager` field.
 
 ## Motivation
 
@@ -46,9 +57,13 @@ v18.18.0
 
 This happens because nix bundles all dependencies into every package, yarn is getting it’s own copy of Node.js, which may be more recent than the Node.js version the project is using.
 
-Corepack by default tries to install shim scripts for both `yarn` and `pnpm` in the same directory that `node` is found in. Unfortunately when using devbox, the `node` binary is in the Nix store, which is read only, so Corepack fails to set up correctly.
+Corepack is a tool included with Node.js that manages PNPM and Yarn versions for you, installing the requested versions as needed and switching seamlessly. Using Corepack would mean that we don't need Devbox / Nix to provide pnpm or Yarn binaries.
 
-This plugin works by:
+But corepack by default tries to install shim scripts for both `yarn` and `pnpm` in the same directory that `node` is found in. Unfortunately when using devbox, the `node` binary is in the Nix store, which is read only, so Corepack gives an error similar to:
+
+> `Internal Error: EACCES: permission denied, unlink '/nix/store/0r6wvd9rr6lsrv8j9b3nv9s9lw7vfb37-profile/bin/pnpm'`
+
+This Devbox plugin works by:
 
 - creating a folder in `.devbox/virtenv/pnpm_plugin/bin/`
 - running `corepack enable --install-directory "./devbox/virtenv/pnpm_plugin/bin/"`, which adds the `pnpm` and `yarn` shim scripts

--- a/plugins/corepack/plugin.json
+++ b/plugins/corepack/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "corepack",
+  "version": "0.0.1",
+  "readme": "README.md",
+  "env": {
+    "PATH": "{{ .Virtenv }}/bin/:$PATH"
+  },
+  "shell": {
+    "init_hook": [
+      "mkdir -p {{ .Virtenv }}/bin",
+      "corepack enable --install-directory \"{{ .Virtenv }}/bin/\""
+    ]
+  }
+}


### PR DESCRIPTION
Adds a corepack plugin that enables [Corepack](https://nodejs.org/api/corepack.html) to handle PNPM and Yarn version installs while using the same version of Node.js as the project.

## Motivation

(largely copy-pasted from @jay-aye-see-kay's explanation on Slack)

There’s a subtle but messy issue that can arise using Devbox, Node.js, and Yarn/PNPM. If you install node and yarn as documented you will end up with two different versions of node:

```sh
$ devbox add nodejs@20.8 yarn
...
$ devbox run node --version
v20.8.0
$ devbox run yarn node --version
yarn node v1.22.19
v18.18.0
```

This happens because nix bundles all dependencies into every package, yarn is getting it’s own copy of Node.js, which may be more recent than the Node.js version the project is using.

Corepack by default tries to install shim scripts for both `yarn` and `pnpm` in the same directory that `node` is found in. Unfortunately when using devbox, the `node` binary is in the Nix store, which is read only, so Corepack fails to set up correctly.

## How the plugin works works

- creating a folder in `.devbox/virtenv/pnpm_plugin/bin/`
- running `corepack enable --install-directory "./devbox/virtenv/pnpm_plugin/bin/"`, which adds the `pnpm` and `yarn` shim scripts
- and then adding `./devbox/virtenv/pnpm_plugin/bin/` to the `PATH` environment variable.

## Testing

Devbox doesn't seem to allow using a plugin from Github with a branch ([it's hard-coded to "master"](https://github.com/jetpack-io/devbox/blob/10c436f4454a423395324d8a647151825cd8ee79/internal/plugin/github.go#L44)), but I tested this on employee-imports: https://github.com/cultureamp/employee-imports/compare/jasono/demonstrate-corepack-plugin?expand=1

It might be worth setting up the unit tests to cover our plugins, perhaps even as part of this PR

Jira card: https://cultureamp.atlassian.net/browse/FEF-879
See also issue on Devbox repo: https://github.com/jetpack-io/devbox/issues/1577