### PR TITLE
update corepack dir to be unique even if shared with other plugins

### DIFF
--- a/plugins/corepack/README.md
+++ b/plugins/corepack/README.md
@@ -65,6 +65,7 @@ But corepack by default tries to install shim scripts for both `yarn` and `pnpm`
 
 This Devbox plugin works by:
 
-- creating a folder in `.devbox/virtenv/pnpm_plugin/bin/`
-- running `corepack enable --install-directory "./devbox/virtenv/pnpm_plugin/bin/"`, which adds the `pnpm` and `yarn` shim scripts
-- and then adding `./devbox/virtenv/pnpm_plugin/bin/` to the `PATH` environment variable.
+- creating a folder in `{{ .Virtenv }}/corepack-bin`
+- running `corepack enable --install-directory "{{ .Virtenv }}/corepack-bin"`, which adds the `pnpm` and `yarn` shim scripts
+- and then adding `{{ .Virtenv }}/corepack-bin` to the `PATH` environment variable.
+- where `{{ .Virtenv }}` is a directory the plugin manages, and will be something like `.devbox/virtenv/cultureamp-devbox-extras/`

--- a/plugins/corepack/plugin.json
+++ b/plugins/corepack/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "corepack",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "readme": "README.md",
   "env": {
-    "PATH": "{{ .Virtenv }}/bin/:$PATH"
+    "PATH": "{{ .Virtenv }}/corepack-bin/:$PATH"
   },
   "shell": {
     "init_hook": [
-      "mkdir -p {{ .Virtenv }}/bin",
-      "corepack enable --install-directory \"{{ .Virtenv }}/bin/\""
+      "mkdir -p {{ .Virtenv }}/corepack-bin",
+      "corepack enable --install-directory \"{{ .Virtenv }}/corepack-bin/\""
     ]
   }
 }


### PR DESCRIPTION
- I noticed when using this plugin repos it would use the directory `.devbox/virtenv/cultureamp-devbox-extras/bin` i.e plugins are only namespaced by repo name, and we have multiple plugins in this repo, so at the moment they'll all share the same `{{ .Virtenv }}` directory
- For now the fix is to rename the directory we use to something more unique, we should probably open this as an issue upstream too
- also update docs so they don't reference a "pnpm plugin", I think this was a typo