### PR TITLE
Add mongo 6 0 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tooling install for local development environments
 
 You can find the install script for the local development environment at [./scripts/bootstrap.sh](./scripts/bootstrap.sh).
-The recommended command to run this install script is: 
+The recommended command to run this install script is:
 
 `curl --proto '=https' --tlsv1.2 -sSf -L https://raw.githubusercontent.com/cultureamp/devbox-extras/main/scripts/bootstrap.sh | sh`
 

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703013332,
-        "narHash": "sha256-+tFNwMvlXLbJZXiMHqYq77z/RfmpfpiI3yjL6o/Zo9M=",
+        "lastModified": 1709479366,
+        "narHash": "sha256-n6F0n8UV6lnTZbYPl1A9q1BS0p4hduAv1mGAP17CVd0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6",
+        "rev": "b8697e57f10292a6165a20f03d2f42920dfaf973",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
 
         packages = {
           mongodb-4_4 = pkgs.callPackage ./packages/mongodb-4_4.nix { };
+          mongodb-6_0 = pkgs.callPackage ./packages/mongodb-6_0.nix { };
           dynamodb_local = pkgs.callPackage ./packages/dynamodb_local.nix { };
           adr-tools = pkgs.callPackage ./packages/adr-tools.nix { };
         };

--- a/packages/mongodb-4_4.nix
+++ b/packages/mongodb-4_4.nix
@@ -9,11 +9,11 @@ if !stdenv.isDarwin then
 else
   stdenv.mkDerivation rec {
     pname = "mongodb-4_4";
-    version = "4.4.25";
+    version = "4.4.28";
 
     src = fetchzip {
       url = "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-${version}.tgz";
-      hash = "sha256-zZtpcSFhzxdC39pJY4F+yaoc4RXfcP+e2lnw8wi/avk=";
+      hash = "sha256-0K4yL2UMfM02/rzD8Xx2TwG1Zi0bZbn7hopd4g/1NoM=";
     };
 
     installPhase = ''

--- a/packages/mongodb-6_0.nix
+++ b/packages/mongodb-6_0.nix
@@ -1,6 +1,7 @@
 { system, stdenv, fetchzip, mongodb-6_0 }:
-# compiling mongodb is slow (10-30mins) so for macOS will pull in the binary from mongo's
-# download page (same a homebrew's packing does)
+# compiling mongodb is slow (10-30mins) so for macOS we pull in the binary from mongo's
+# download page (same a homebrew's package does)
+# see: https://www.mongodb.com/download-center/community/releases
 
 let
   pname = "mongodb-6_0";

--- a/packages/mongodb-6_0.nix
+++ b/packages/mongodb-6_0.nix
@@ -5,7 +5,7 @@
 
 let
   pname = "mongodb-6_0";
-  version = "6.0.14";
+  version = "6.0.13";
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin
@@ -21,7 +21,7 @@ if system == "x86_64-darwin" then
 
     src = fetchzip {
       url = "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-${version}.tgz";
-      hash = "sha256-ZW8GMRr5wXGOyBy12Dq5CnTxpqda/csfszuoYZ1pRtM=";
+      hash = "sha256-2ZyrMsXxt4AZPWbrSKcu89Uys9yCpEYDqpxqpNIcPmY=";
     };
   }
 
@@ -32,7 +32,7 @@ else if system == "aarch64-darwin" then
 
     src = fetchzip {
       url = "https://fastdl.mongodb.org/osx/mongodb-macos-arm64-${version}.tgz";
-      hash = "sha256-F6etuVeRMGZGyfQKdhrTy6LvFNHCIgrZDOzxOw/jCus=";
+      hash = "sha256-C0eW1CHKiF308QsPbFcS/7nLHYDmVboUynGn6VxQtA8=";
     };
   }
 

--- a/packages/mongodb-6_0.nix
+++ b/packages/mongodb-6_0.nix
@@ -1,6 +1,6 @@
 { system, stdenv, fetchzip, mongodb-6_0 }:
 # compiling mongodb is slow (10-30mins) so for macOS we pull in the binary from mongo's
-# download page (same a homebrew's package does)
+# download page (same as homebrew's package does)
 # see: https://www.mongodb.com/download-center/community/releases
 
 let

--- a/packages/mongodb-6_0.nix
+++ b/packages/mongodb-6_0.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchzip, mongodb-6_0 }:
+
+# the linux builds of mongo work fine, so default to the standard nixpkgs version if we're on linux
+if !stdenv.isDarwin then
+  mongodb-6_0
+
+# aarch darwin builds of this version of mongo don't exist, and compiling the x86 version is >20mins
+# so provide the x86 binary version to any macOS system (this is exactly what homebrew does)
+else
+  stdenv.mkDerivation rec {
+    pname = "mongodb-6_0";
+    version = "6.0.13";
+
+    src = fetchzip {
+      url = "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-${version}.tgz";
+      hash = "sha256-2ZyrMsXxt4AZPWbrSKcu89Uys9yCpEYDqpxqpNIcPmY=";
+    };
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/bin
+      cp bin/{mongod,mongos} $out/bin/
+      runHook postInstall
+    '';
+  }

--- a/packages/mongodb-6_0.nix
+++ b/packages/mongodb-6_0.nix
@@ -16,7 +16,7 @@ in
 
 if system == "x86_64-darwin" then
   stdenv.mkDerivation
-  rec {
+  {
     inherit pname version installPhase;
 
     src = fetchzip {


### PR DESCRIPTION
Add mongo 6 0 package.

This is so we can install mongo by downloading a binary rather than compiling (which is what happens if you use the nixpkgs package) to save about 20mins.

`bin/mongo` is no longer included so it has been removed.
https://www.mongodb.com/docs/v4.4/mongo/#std-label-compare-mongosh-mongo

Verified that package works in this commit https://github.com/cultureamp/murmur/pull/23612/commits/81fa6285999220952a48ef2ff0ebb3a2aa11c0ea