### PR TITLE
update devbox action to new version and org name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,5 +37,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: jetpack-io/devbox-install-action@v0.7.0
+      - uses: jetify-com/devbox-install-action@v0.9.0
       - run: devbox run lint


### PR DESCRIPTION
Noticed issue in https://github.com/cultureamp/local-ops/pull/27, which will affect this repo too

Searching the company github these are the only two repos that use this action https://github.com/search?q=org%3Acultureamp+jetpack-io%2Fdevbox-install-action&type=code