### PR TITLE
deprecate corepack plugin

### DIFF
--- a/plugins/corepack/README.md
+++ b/plugins/corepack/README.md
@@ -1,3 +1,7 @@
+> [!WARNING]
+> This plugin is built into devbox since v0.10 and should not be included from this repo anymore.
+> [see devbox docs for usage](https://www.jetify.com/devbox/docs/devbox_examples/languages/nodejs/#adding-yarn-npm-or-pnpm-as-your-node-package-manager)
+
 # Corepack plugin
 
 This plugin sets up [Corepack](https://github.com/nodejs/corepack/), a NodeJS feature to automatically install the correct version of Yarn or PNPM.

--- a/plugins/corepack/README.md
+++ b/plugins/corepack/README.md
@@ -2,6 +2,20 @@
 > This plugin is built into devbox since v0.10 and should not be included from this repo anymore.
 > [see devbox docs for usage](https://www.jetify.com/devbox/docs/devbox_examples/languages/nodejs/#adding-yarn-npm-or-pnpm-as-your-node-package-manager)
 
+To switch to the built in plugin, in your devbox.json remove the include and add `DEVBOX_COREPACK_ENABLED=true` to your env:
+```diff
+{
+  "packages": ["nodejs@18.19.1"],
+  "include": [
+-    "github:cultureamp/devbox-extras?dir=plugins/corepack"
+  ]
+  "env": {
++    "DEVBOX_COREPACK_ENABLED": "true"
+  }
+}
+```
+
+
 # Corepack plugin
 
 This plugin sets up [Corepack](https://github.com/nodejs/corepack/), a NodeJS feature to automatically install the correct version of Yarn or PNPM.

--- a/plugins/corepack/plugin.json
+++ b/plugins/corepack/plugin.json
@@ -7,7 +7,7 @@
   },
   "shell": {
     "init_hook": [
-      "echo WARNING: corepack plugin is built into devbox since v0.10 and can be removed from devbox.json",
+      "echo WARNING: corepack plugin is built into devbox since v0.10 and can be removed from devbox.json and replaced with the env var DEVBOX_COREPACK_ENABLED=1",
       "mkdir -p {{ .Virtenv }}/corepack-bin",
       "corepack enable --install-directory \"{{ .Virtenv }}/corepack-bin/\""
     ]

--- a/plugins/corepack/plugin.json
+++ b/plugins/corepack/plugin.json
@@ -1,12 +1,13 @@
 {
   "name": "corepack",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "readme": "README.md",
   "env": {
     "PATH": "{{ .Virtenv }}/corepack-bin/:$PATH"
   },
   "shell": {
     "init_hook": [
+      "echo WARNING: corepack plugin is built into devbox since v0.10 and can be removed from devbox.json",
       "mkdir -p {{ .Virtenv }}/corepack-bin",
       "corepack enable --install-directory \"{{ .Virtenv }}/corepack-bin/\""
     ]


### PR DESCRIPTION
Plugin was upstreamed a few weeks ago, no need to install it explicitly - though there's currently no harm either, it can be confusing.

Puts a warning in the init_hook and readme so it's more clear. Will also make sure our internal docs are up to date.
