### PR TITLE
Add multi gitter flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
           mongodb-6_0 = pkgs.callPackage ./packages/mongodb-6_0.nix { };
           dynamodb_local = pkgs.callPackage ./packages/dynamodb_local.nix { };
           adr-tools = pkgs.callPackage ./packages/adr-tools.nix { };
+          multi-gitter = pkgs.callPackage ./packages/multi-gitter.nix { };
         };
       });
 }

--- a/packages/multi-gitter.nix
+++ b/packages/multi-gitter.nix
@@ -1,0 +1,45 @@
+{ system, lib, stdenv, fetchzip }:
+let
+  inherit (lib) licenses;
+  pname = "multi-gitter-${version}";
+  version = "0.52.0";
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp bin/multi-gitter $out/bin/multi-gitter
+    runHook postInstall
+  '';
+  dontStrip = true;
+  meta = with lib; {
+    description = "A tool to manage multiple git repositories";
+    license = licenses.asl20;
+    platforms = platforms.darwin;
+  };
+in
+
+if system == "x86_64-darwin" then
+  stdenv.mkDerivation
+  {
+    inherit pname version installPhase dontStrip meta;
+
+    src = fetchzip {
+      url = "https://github.com/lindell/multi-gitter/releases/download/v${version}/multi-gitter_${version}_Darwin_ARM64.tar.gz";
+      hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      stripRoot = false;
+    };
+  }
+
+else if system == "aarch64-darwin" then
+  stdenv.mkDerivation
+  {
+    inherit pname version installPhase dontStrip meta;
+
+    src = fetchzip {
+      url = "https://github.com/lindell/multi-gitter/releases/download/v${version}/multi-gitter_${version}_Darwin_x86_64.tar.gz";
+      hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      stripRoot = false;
+    };
+  }
+
+else
+  abort "unsupported system"

--- a/packages/multi-gitter.nix
+++ b/packages/multi-gitter.nix
@@ -24,7 +24,7 @@ if system == "x86_64-darwin" then
 
     src = fetchzip {
       url = "https://github.com/lindell/multi-gitter/releases/download/v${version}/multi-gitter_${version}_Darwin_ARM64.tar.gz";
-      hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      hash = "sha256-DkqcQrz0PLjb21skaks6BrdLyxEymhmkdH8vFNrGJqQ=";
       stripRoot = false;
     };
   }
@@ -36,7 +36,7 @@ else if system == "aarch64-darwin" then
 
     src = fetchzip {
       url = "https://github.com/lindell/multi-gitter/releases/download/v${version}/multi-gitter_${version}_Darwin_x86_64.tar.gz";
-      hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      hash = "sha256-k+vngTWJZ/ySiDWPVWBZdoGnaKyUMffY2au6WGYClLQ=";
       stripRoot = false;
     };
   }


### PR DESCRIPTION
Multi gitter is the tool chosen by SRE to do batch updates in the fleet-upgrades repo.
I have been playing around with it as well but had to install it via brew due to it not being in the nix package registry.
If we want to do more experiments with it I would like to be able to install it with devbox.

This PR adds a flake for multi-gitter