### PR TITLE
add pipx plugin

### DIFF
--- a/plugins/pipx/plugin.json
+++ b/plugins/pipx/plugin.json
@@ -2,7 +2,7 @@
   "name": "pipx",
   "version": "0.1.0",
   "description": "Installs Pipx and makes it available",
-  "packages": ["pipx@latest"],
+  "packages": ["pipx@1.4"],
   "env": {
     "PIPX_HOME": "{{ .Virtenv }}",
     "PIPX_BIN_DIR": "{{ .Virtenv }}/bin"

--- a/plugins/pipx/plugin.json
+++ b/plugins/pipx/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "pipx",
+  "version": "0.1.0",
+  "description": "Installs Pipx and makes it available",
+  "packages": ["pipx@latest"],
+  "env": {
+    "PIPX_HOME": "{{ .Virtenv }}",
+    "PIPX_BIN_DIR": "{{ .Virtenv }}/bin"
+  },
+  "shell": {
+      "init_hook": [
+          "export PATH=\"{{ .Virtenv }}/bin:$PATH\""
+      ]
+  }
+}


### PR DESCRIPTION
adds plugin to install [pipx](https://pipx.pypa.io) which can be used to bootstrap other system level python tools, such as Poetry