### PR TITLE
Add a ca-kafka-local plugin

### DIFF
--- a/plugins/ca-kafka-local/README.md
+++ b/plugins/ca-kafka-local/README.md
@@ -37,3 +37,15 @@ You can have another service depend on Kafka in your `process-compose.yaml`:
       depends_on:
         kafka_local:
           condition: process_healthy
+
+## Anti-patterns to avoid: circular dependency on hotel
+
+Please don't start Kafka within your projects `process-compose.yaml` file. For example
+
+    # PLEASE DO NOT DO THIS
+    kafka:
+      command: hotel services up kafka-local
+
+We don't want to set up circular loops where Hotel launches `devbox services up` and then this launches Hotel again.
+
+For now run Hotel commands in a separate terminal. In future we might provide helpers in Hotel that launch services in your project as well as projects you depend on.

--- a/plugins/ca-kafka-local/README.md
+++ b/plugins/ca-kafka-local/README.md
@@ -6,9 +6,7 @@ Use this plugin to interact with `kafka-local` in your service. You still need t
 
 What it provides:
 
-- Environment variables
-  - `KAFKA_BROKERS` set to `"localhost:14231"`
-  - `SCHEMA_REGISTRY_URL` set to `"localhost:14228"`
+- Environment variables. See [plugin.json](./plugin.json) for which variables are supplied and their values. They match those used in `kafka-local`.
 - Process Compose job
   - Will print information to the terminal about Kafka, once `kafka-local` is up and running.
   - Allows you to add a `depends_on` clause so other services wait for `kafka-local`.

--- a/plugins/ca-kafka-local/README.md
+++ b/plugins/ca-kafka-local/README.md
@@ -1,0 +1,39 @@
+# CA Kafka Local Devbox Plugin
+
+At Culture Amp we use Kafka for sharing data between services, and the private [kafka-local](https://github.com/cultureamp/kafka-local) repo is how we run that locally.
+
+Use this plugin to interact with `kafka-local` in your service. You still need to launch Kafka on your own, but this plugin provides environment variables and tools to make it easy for your project to connect to `kafka-local`.
+
+What it provides:
+
+- Environment variables
+  - `KAFKA_BROKERS` set to `"localhost:14231"`
+  - `SCHEMA_REGISTRY_URL` set to `"localhost:14228"`
+- Process Compose job
+  - Will print information to the terminal about Kafka, once `kafka-local` is up and running.
+  - Allows you to add a `depends_on` clause so other services wait for `kafka-local`.
+
+## Usage
+
+To start Kafka
+
+- Use [Hotel CLI](https://github.com/cultureamp/hotel)
+- Run `hotel services up kafka-local`
+- In your repo run `devbox services up`
+
+Include the plugin in your `devbox.json`:
+
+    {
+      "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox.schema.json",
+      "include": [
+        "github:cultureamp/devbox-extras?dir=plugins/ca-kafka-local"
+      ]
+    }
+
+You can have another service depend on Kafka in your `process-compose.yaml`:
+
+    projectors_process:
+      command: "./gradlew run-projectors"
+      depends_on:
+        kafka_local:
+          condition: process_healthy

--- a/plugins/ca-kafka-local/bin/kafka-local-readme
+++ b/plugins/ca-kafka-local/bin/kafka-local-readme
@@ -12,6 +12,7 @@ echo
 echo "== Environment variables =="
 echo "KAFKA_BROKERS: ${KAFKA_BROKERS}"
 echo "SCHEMA_REGISTRY_URL: ${SCHEMA_REGISTRY_URL}"
+echo "KAFKA_TOPIC_PREFIX: ${KAFKA_TOPIC_PREFIX}"
 echo
 echo "== Links =="
 echo "Kafka UI: http://${KAFKA_UI_URL}"

--- a/plugins/ca-kafka-local/bin/kafka-local-readme
+++ b/plugins/ca-kafka-local/bin/kafka-local-readme
@@ -15,5 +15,5 @@ echo "SCHEMA_REGISTRY_URL: ${SCHEMA_REGISTRY_URL}"
 echo "KAFKA_TOPIC_PREFIX: ${KAFKA_TOPIC_PREFIX}"
 echo
 echo "== Links =="
-echo "Kafka UI: http://${KAFKA_UI_URL}"
+echo "Kafka UI: ${KAFKA_UI_URL}"
 echo "Schema Registry: http://${SCHEMA_REGISTRY_URL}"

--- a/plugins/ca-kafka-local/bin/kafka-local-readme
+++ b/plugins/ca-kafka-local/bin/kafka-local-readme
@@ -13,3 +13,6 @@ echo "== Environment variables =="
 echo "KAFKA_BROKERS: ${KAFKA_BROKERS}"
 echo "SCHEMA_REGISTRY_URL: ${SCHEMA_REGISTRY_URL}"
 echo
+echo "== Links =="
+echo "Kafka UI: http://${KAFKA_UI_URL}"
+echo "Schema Registry: http://${SCHEMA_REGISTRY_URL}"

--- a/plugins/ca-kafka-local/bin/kafka-local-readme
+++ b/plugins/ca-kafka-local/bin/kafka-local-readme
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+echo
+echo "== LOCAL KAFKA =="
+echo "To start Kafka Local (https://github.com/cultureamp/kafka-local):"
+echo "  hotel services up kafka-local"
+echo
+echo "Once all Kafka services are up and running, this step will be considered healthy"
+echo
+echo "== Environment variables =="
+echo "KAFKA_BROKERS: ${KAFKA_BROKERS}"
+echo "SCHEMA_REGISTRY_URL: ${SCHEMA_REGISTRY_URL}"
+echo

--- a/plugins/ca-kafka-local/config/process-compose.yaml
+++ b/plugins/ca-kafka-local/config/process-compose.yaml
@@ -1,0 +1,15 @@
+version: "0.5"
+
+processes:
+  kafka_local:
+    # This doesn't actually start Local Kafka, but it prints information about Kafka running, and allows you to do `depends_on: kafka_local`
+    command: "devbox run kafka-local-readme; tail -f /dev/null"
+    readiness_probe:
+      # This ensures kafka-ui is up and running, which means Kafka and Schema Registry are up and healthy.
+      # The ports are static and defined in our `local-ops` repo, and it's safe to assume it won't change.
+      http_get:
+        host: localhost
+        port: 12288
+      failure_threshold: 999
+    availability:
+      restart: always

--- a/plugins/ca-kafka-local/plugin.json
+++ b/plugins/ca-kafka-local/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "ca-kafka-local",
+  "version": "0.0.1",
+  "description": "Environment variables and tools to interact with `kafka-local` in your service",
+  "readme": "README.md",
+  "env": {
+    "KAFKA_BROKERS": "localhost:14231",
+    "SCHEMA_REGISTRY_URL": "localhost:14228"
+  },
+  "create_files": {
+    "{{.Virtenv}}/bin/kafka-local-readme": "bin/kafka-local-readme",
+    "{{.Virtenv}}/config/process-compose.yaml": "config/process-compose.yaml"
+  },
+  "shell": {
+    "scripts": {
+      "kafka-local-readme": "{{.Virtenv}}/bin/kafka-local-readme"
+    }
+  }
+}

--- a/plugins/ca-kafka-local/plugin.json
+++ b/plugins/ca-kafka-local/plugin.json
@@ -5,7 +5,8 @@
   "readme": "README.md",
   "env": {
     "KAFKA_BROKERS": "localhost:14231",
-    "SCHEMA_REGISTRY_URL": "localhost:14228"
+    "SCHEMA_REGISTRY_URL": "localhost:14228",
+    "KAFKA_UI_URL": "http://localhost:12288"
   },
   "create_files": {
     "{{.Virtenv}}/bin/kafka-local-readme": "bin/kafka-local-readme",

--- a/plugins/ca-kafka-local/plugin.json
+++ b/plugins/ca-kafka-local/plugin.json
@@ -6,6 +6,7 @@
   "env": {
     "KAFKA_BROKERS": "localhost:14231",
     "SCHEMA_REGISTRY_URL": "localhost:14228",
+    "KAFKA_TOPIC_PREFIX": "local",
     "KAFKA_UI_URL": "http://localhost:12288"
   },
   "create_files": {


### PR DESCRIPTION
Add a `ca-kafka-local` plugin.

## Context

This ties into our (private) https://github.com/cultureamp/local-kafka repo. It does not start the service, but it provides environment variables your project can use to connect to the service, a README with links, and the ability to set one of your services as `depends_on: kafka_local`.

Jira card: https://cultureamp.atlassian.net/browse/FEF-1537

## Testing

I've tested on this branch of develop-module:
https://github.com/cultureamp/develop-module/compare/jasono/test-kafka-devbox-plugin?expand=1