### PR TITLE
Start installing various Kafka CLI tools in ca-kafka-local plugin

### DIFF
--- a/plugins/ca-kafka-local/README.md
+++ b/plugins/ca-kafka-local/README.md
@@ -10,6 +10,8 @@ What it provides:
 - Process Compose job
   - Will print information to the terminal about Kafka, once `kafka-local` is up and running.
   - Allows you to add a `depends_on` clause so other services wait for `kafka-local`.
+- CLI Tools
+  - [kafkactl](https://deviceinsight.github.io/kafkactl/) for basic kafka interactions.
 
 ## Usage
 

--- a/plugins/ca-kafka-local/README.md
+++ b/plugins/ca-kafka-local/README.md
@@ -10,8 +10,10 @@ What it provides:
 - Process Compose job
   - Will print information to the terminal about Kafka, once `kafka-local` is up and running.
   - Allows you to add a `depends_on` clause so other services wait for `kafka-local`.
-- CLI Tools
-  - [kafkactl](https://deviceinsight.github.io/kafkactl/) for basic kafka interactions.
+- Various Kafka CLI Tools
+  - [kafkactl](https://deviceinsight.github.io/kafkactl/). We add a configuration file for connecting to `kafka-local` out of the box.
+  - [kcat](https://github.com/edenhill/kcat). We add a configuration file for connecting to `kafka-local` out of the box.
+  - [kaf](https://github.com/birdayz/kaf). Note you will need to run `kaf config add-cluster local -b $KAFKA_BROKERS` and then `kaf config select-cluster` to configure connection to `kafka-local`.
 
 ## Usage
 

--- a/plugins/ca-kafka-local/README.md
+++ b/plugins/ca-kafka-local/README.md
@@ -10,10 +10,10 @@ What it provides:
 - Process Compose job
   - Will print information to the terminal about Kafka, once `kafka-local` is up and running.
   - Allows you to add a `depends_on` clause so other services wait for `kafka-local`.
-- Various Kafka CLI Tools
-  - [kafkactl](https://deviceinsight.github.io/kafkactl/). We add a configuration file for connecting to `kafka-local` out of the box.
-  - [kcat](https://github.com/edenhill/kcat). We add a configuration file for connecting to `kafka-local` out of the box.
-  - [kaf](https://github.com/birdayz/kaf). Note you will need to run `kaf config add-cluster local -b $KAFKA_BROKERS` and then `kaf config select-cluster` to configure connection to `kafka-local`.
+- Various Kafka CLI Tools (each with configuration to connect to `kafka-local`)
+  - [kafkactl](https://deviceinsight.github.io/kafkactl/)
+  - [kcat](https://github.com/edenhill/kcat)
+  - [kaf](https://github.com/birdayz/kaf)
 
 ## Usage
 
@@ -51,3 +51,17 @@ Please don't start Kafka within your projects `process-compose.yaml` file. For e
 We don't want to set up circular loops where Hotel launches `devbox services up` and then this launches Hotel again.
 
 For now run Hotel commands in a separate terminal. In future we might provide helpers in Hotel that launch services in your project as well as projects you depend on.
+
+## Creating a topic
+
+You can use one of the CLI tools to create topics your service requires.
+
+For example:
+
+    kafkactl create topic local.mytopic.v1
+
+Or
+
+    kaf topic create local.jasontopic.v3
+
+In future we plan to support creating your topics as defined in [kafka-ops](https://github.com/cultureamp/kafka-ops/).

--- a/plugins/ca-kafka-local/bin/kaf
+++ b/plugins/ca-kafka-local/bin/kaf
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# The Kaf tool doesn't allow setting the config file path via an environment variable.
+# This script is a workaround to set the config file path via the `--config` argument.
+
+KAF_BINARY="$DEVBOX_PACKAGES_DIR/bin/kaf"
+
+if [[ ! -f "$KAF_BINARY" ]]; then
+    echo "Error: $KAF_BINARY was not found in devbox packages."
+    exit 1
+fi
+
+# Call the kaf binary with the `--config` argument and add all passed arguments
+"$KAF_BINARY" --config "$KAF_CONFIG_PATH" "$@"

--- a/plugins/ca-kafka-local/bin/kafka-local-readme
+++ b/plugins/ca-kafka-local/bin/kafka-local-readme
@@ -24,3 +24,5 @@ echo "Schema Registry: http://${SCHEMA_REGISTRY_URL}"
 echo
 echo "== Tools =="
 echo "kafkactl - https://deviceinsight.github.io/kafkactl/"
+echo "kcat - https://github.com/edenhill/kcat"
+echo "kaf - https://github.com/birdayz/kaf"

--- a/plugins/ca-kafka-local/bin/kafka-local-readme
+++ b/plugins/ca-kafka-local/bin/kafka-local-readme
@@ -21,3 +21,6 @@ echo
 echo "== Links =="
 echo "Kafka UI: ${KAFKA_UI_URL}"
 echo "Schema Registry: http://${SCHEMA_REGISTRY_URL}"
+echo
+echo "== Tools =="
+echo "kafkactl - https://deviceinsight.github.io/kafkactl/"

--- a/plugins/ca-kafka-local/config/kaf/config
+++ b/plugins/ca-kafka-local/config/kaf/config
@@ -1,0 +1,10 @@
+current-cluster: local
+clusters:
+  - name: local
+    brokers:
+      - ${KAFKA_BROKERS_SASL}
+    SASL:
+      mechanism: SCRAM-SHA-512
+      username: ${KAFKA_SASL_USER}
+      password: ${KAFKA_SASL_PASSWORD}
+    security-protocol: SASL_PLAINTEXT

--- a/plugins/ca-kafka-local/config/kafkactl/config.yaml
+++ b/plugins/ca-kafka-local/config/kafkactl/config.yaml
@@ -2,14 +2,16 @@
 contexts:
   local:
     brokers:
-      - ${KAFKA_BROKERS}
+      - ${KAFKA_BROKERS_SASL}
 
     tls:
       enabled: false
 
-    # Waiting on https://github.com/cultureamp/local-kafka/pull/4
     sasl:
-      enabled: false
+      enabled: true
+      username: ${KAFKA_SASL_USER}
+      password: ${KAFKA_SASL_PASSWORD}
+      mechanism: scram-sha512
 
     avro:
       schemaRegistry: ${SCHEMA_REGISTRY_URL}

--- a/plugins/ca-kafka-local/config/kafkactl/config.yaml
+++ b/plugins/ca-kafka-local/config/kafkactl/config.yaml
@@ -2,7 +2,7 @@
 contexts:
   local:
     brokers:
-      - localhost:14231
+      - ${KAFKA_BROKERS}
 
     tls:
       enabled: false
@@ -12,6 +12,6 @@ contexts:
       enabled: false
 
     avro:
-      schemaRegistry: localhost:14228
+      schemaRegistry: ${SCHEMA_REGISTRY_URL}
 
 current-context: local

--- a/plugins/ca-kafka-local/config/kafkactl/config.yaml
+++ b/plugins/ca-kafka-local/config/kafkactl/config.yaml
@@ -1,0 +1,17 @@
+# See https://github.com/deviceinsight/kafkactl?tab=readme-ov-file#configuration
+contexts:
+  local:
+    brokers:
+      - localhost:14231
+
+    tls:
+      enabled: false
+
+    # Waiting on https://github.com/cultureamp/local-kafka/pull/4
+    sasl:
+      enabled: false
+
+    avro:
+      schemaRegistry: localhost:14228
+
+current-context: local

--- a/plugins/ca-kafka-local/config/kcat/kcat.conf
+++ b/plugins/ca-kafka-local/config/kcat/kcat.conf
@@ -1,1 +1,5 @@
-bootstrap.servers=${KAFKA_BROKERS}
+bootstrap.servers=${KAFKA_BROKERS_SASL}
+security.protocol=SASL_PLAINTEXT
+sasl.mechanisms=SCRAM-SHA-512
+sasl.username=${KAFKA_SASL_USER}
+sasl.password=${KAFKA_SASL_PASSWORD}

--- a/plugins/ca-kafka-local/config/kcat/kcat.conf
+++ b/plugins/ca-kafka-local/config/kcat/kcat.conf
@@ -1,0 +1,1 @@
+bootstrap.servers=${KAFKA_BROKERS}

--- a/plugins/ca-kafka-local/plugin.json
+++ b/plugins/ca-kafka-local/plugin.json
@@ -5,6 +5,7 @@
   "readme": "README.md",
   "packages": ["kafkactl@5", "kcat@1", "envsubst", "kaf"],
   "env": {
+    "PATH": "{{ .Virtenv }}/bin:$PATH",
     "KAFKA_BROKERS": "localhost:14231",
     "KAFKA_BROKERS_SASL": "localhost:14233",
     "KAFKA_SASL_PORT": "14233",
@@ -14,18 +15,22 @@
     "KAFKA_TOPIC_PREFIX": "local",
     "KAFKA_UI_URL": "http://localhost:12288",
     "KAFKA_CTL_CONFIG": "{{.Virtenv}}/config/kafkactl/config.yaml",
-    "KCAT_CONFIG": "{{.Virtenv}}/config/kcat/kcat.conf"
+    "KCAT_CONFIG": "{{.Virtenv}}/config/kcat/kcat.conf",
+    "KAF_CONFIG_PATH": "{{.Virtenv}}/config/kaf/config"
   },
   "create_files": {
     "{{.Virtenv}}/bin/kafka-local-readme": "bin/kafka-local-readme",
+    "{{.Virtenv}}/bin/kaf": "bin/kaf",
     "{{.Virtenv}}/config/process-compose.yaml": "config/process-compose.yaml",
     "{{.Virtenv}}/config/kafkactl/config.yaml.template": "config/kafkactl/config.yaml",
-    "{{.Virtenv}}/config/kcat/kcat.conf.template": "config/kcat/kcat.conf"
+    "{{.Virtenv}}/config/kcat/kcat.conf.template": "config/kcat/kcat.conf",
+    "{{.Virtenv}}/config/kaf/config.template": "config/kaf/config"
   },
   "shell": {
     "init_hook": [
       "envsubst < {{.Virtenv}}/config/kafkactl/config.yaml.template > {{.Virtenv}}/config/kafkactl/config.yaml",
-      "envsubst < {{.Virtenv}}/config/kcat/kcat.conf.template > {{.Virtenv}}/config/kcat/kcat.conf"
+      "envsubst < {{.Virtenv}}/config/kcat/kcat.conf.template > {{.Virtenv}}/config/kcat/kcat.conf",
+      "envsubst < {{.Virtenv}}/config/kaf/config.template > {{.Virtenv}}/config/kaf/config"
     ],
     "scripts": {
       "kafka-local-readme": "{{.Virtenv}}/bin/kafka-local-readme"

--- a/plugins/ca-kafka-local/plugin.json
+++ b/plugins/ca-kafka-local/plugin.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Environment variables and tools to interact with `kafka-local` in your service",
   "readme": "README.md",
+  "packages": ["kafkactl@5"],
   "env": {
     "KAFKA_BROKERS": "localhost:14231",
     "KAFKA_BROKERS_SASL": "localhost:14233",
@@ -11,11 +12,13 @@
     "KAFKA_SASL_PASSWORD": "user-secret",
     "SCHEMA_REGISTRY_URL": "localhost:14228",
     "KAFKA_TOPIC_PREFIX": "local",
-    "KAFKA_UI_URL": "http://localhost:12288"
+    "KAFKA_UI_URL": "http://localhost:12288",
+    "KAFKA_CTL_CONFIG": "{{.Virtenv}}/config/kafkactl/config.yaml"
   },
   "create_files": {
     "{{.Virtenv}}/bin/kafka-local-readme": "bin/kafka-local-readme",
-    "{{.Virtenv}}/config/process-compose.yaml": "config/process-compose.yaml"
+    "{{.Virtenv}}/config/process-compose.yaml": "config/process-compose.yaml",
+    "{{.Virtenv}}/config/kafkactl/config.yaml": "config/kafkactl/config.yaml"
   },
   "shell": {
     "scripts": {

--- a/plugins/ca-kafka-local/plugin.json
+++ b/plugins/ca-kafka-local/plugin.json
@@ -19,11 +19,12 @@
   "create_files": {
     "{{.Virtenv}}/bin/kafka-local-readme": "bin/kafka-local-readme",
     "{{.Virtenv}}/config/process-compose.yaml": "config/process-compose.yaml",
-    "{{.Virtenv}}/config/kafkactl/config.yaml": "config/kafkactl/config.yaml",
+    "{{.Virtenv}}/config/kafkactl/config.yaml.template": "config/kafkactl/config.yaml",
     "{{.Virtenv}}/config/kcat/kcat.conf.template": "config/kcat/kcat.conf"
   },
   "shell": {
     "init_hook": [
+      "envsubst < {{.Virtenv}}/config/kafkactl/config.yaml.template > {{.Virtenv}}/config/kafkactl/config.yaml",
       "envsubst < {{.Virtenv}}/config/kcat/kcat.conf.template > {{.Virtenv}}/config/kcat/kcat.conf"
     ],
     "scripts": {

--- a/plugins/ca-kafka-local/plugin.json
+++ b/plugins/ca-kafka-local/plugin.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Environment variables and tools to interact with `kafka-local` in your service",
   "readme": "README.md",
-  "packages": ["kafkactl@5"],
+  "packages": ["kafkactl@5", "kcat@1", "envsubst", "kaf"],
   "env": {
     "KAFKA_BROKERS": "localhost:14231",
     "KAFKA_BROKERS_SASL": "localhost:14233",
@@ -13,14 +13,19 @@
     "SCHEMA_REGISTRY_URL": "localhost:14228",
     "KAFKA_TOPIC_PREFIX": "local",
     "KAFKA_UI_URL": "http://localhost:12288",
-    "KAFKA_CTL_CONFIG": "{{.Virtenv}}/config/kafkactl/config.yaml"
+    "KAFKA_CTL_CONFIG": "{{.Virtenv}}/config/kafkactl/config.yaml",
+    "KCAT_CONFIG": "{{.Virtenv}}/config/kcat/kcat.conf"
   },
   "create_files": {
     "{{.Virtenv}}/bin/kafka-local-readme": "bin/kafka-local-readme",
     "{{.Virtenv}}/config/process-compose.yaml": "config/process-compose.yaml",
-    "{{.Virtenv}}/config/kafkactl/config.yaml": "config/kafkactl/config.yaml"
+    "{{.Virtenv}}/config/kafkactl/config.yaml": "config/kafkactl/config.yaml",
+    "{{.Virtenv}}/config/kcat/kcat.conf.template": "config/kcat/kcat.conf"
   },
   "shell": {
+    "init_hook": [
+      "envsubst < {{.Virtenv}}/config/kcat/kcat.conf.template > {{.Virtenv}}/config/kcat/kcat.conf"
+    ],
     "scripts": {
       "kafka-local-readme": "{{.Virtenv}}/bin/kafka-local-readme"
     }


### PR DESCRIPTION
This will make it easier for us to add topics, among other things.

The tools installed are:
- [kafkactl](https://deviceinsight.github.io/kafkactl/)
- [kcat](https://github.com/edenhill/kcat)
- [kaf](https://github.com/birdayz/kaf)

All 3 tools are small binaries and don't add much weight to the plugin. Kaf and Kcat are already in use elsewhere at Culture Amp, but kafkactl appeared to me to have the nicest combination of UI + docs, so I think is worth including.

I've used `envsubst` to create templated config files for each, and needed a small wrapper script to set the `--config` flag for kaf (for both kcat and kafkactl I was able to set the config path with an environment variable so didn't need a wrapper script).

Example to create a topic:

    kafkactl create topic local.jasontopic.v1

Jira card: https://cultureamp.atlassian.net/browse/FEF-1538