### PR TITLE
Add kafka-local-register-schema script

### DIFF
--- a/plugins/ca-kafka-local/README.md
+++ b/plugins/ca-kafka-local/README.md
@@ -14,13 +14,15 @@ What it provides:
   - [kafkactl](https://deviceinsight.github.io/kafkactl/)
   - [kcat](https://github.com/edenhill/kcat)
   - [kaf](https://github.com/birdayz/kaf)
+- Helper scripts
+  - `kafka-local-register-schema [topic-name] [path/to/schema.avsc]`
 
 ## Usage
 
 To start Kafka
 
 - Use [Hotel CLI](https://github.com/cultureamp/hotel)
-- Run `hotel services up kafka-local`
+- Run `hotel services up kafka`
 - In your repo run `devbox services up`
 
 Include the plugin in your `devbox.json`:
@@ -46,13 +48,15 @@ Please don't start Kafka within your projects `process-compose.yaml` file. For e
 
     # PLEASE DO NOT DO THIS
     kafka:
-      command: hotel services up kafka-local
+      command: hotel services up kafka
 
 We don't want to set up circular loops where Hotel launches `devbox services up` and then this launches Hotel again.
 
 For now run Hotel commands in a separate terminal. In future we might provide helpers in Hotel that launch services in your project as well as projects you depend on.
 
 ## Creating a topic
+
+First ensure `kafka-local` is running with `hotel services up kafka`.
 
 You can use one of the CLI tools to create topics your service requires.
 
@@ -65,3 +69,11 @@ Or
     kaf topic create local.jasontopic.v3
 
 In future we plan to support creating your topics as defined in [kafka-ops](https://github.com/cultureamp/kafka-ops/).
+
+## Registering a schema
+
+First ensure `kafka-local` is running with `hotel services up kafka`.
+
+Then you can use the helper script to register a schema for a topic.
+
+    kafka-local-register-schema <topic-name> <schema-file>

--- a/plugins/ca-kafka-local/bin/kafka-local-readme
+++ b/plugins/ca-kafka-local/bin/kafka-local-readme
@@ -5,7 +5,7 @@ set -e
 echo
 echo "== LOCAL KAFKA =="
 echo "To start Kafka Local (https://github.com/cultureamp/kafka-local):"
-echo "  hotel services up kafka-local"
+echo "  hotel services up kafka"
 echo
 echo "Once all Kafka services are up and running, this step will be considered healthy"
 echo

--- a/plugins/ca-kafka-local/bin/kafka-local-register-schema
+++ b/plugins/ca-kafka-local/bin/kafka-local-register-schema
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Check if topic name and schema file are provided
+if [ -z "$1" ] || [ -z "$2" ]
+then
+  echo "Usage: kafka-local-register-schema <topic-name> <schema-file>"
+  exit 1
+fi
+
+# Set the topic name and schema file
+TOPIC_NAME=$1
+SCHEMA_FILE=$2
+
+# Check if schema file exists
+if [ ! -f "$SCHEMA_FILE" ]
+then
+  echo "Schema file $SCHEMA_FILE does not exist."
+  exit 1
+fi
+
+# Read the Avro schema file
+SCHEMA="$(<$SCHEMA_FILE)"
+
+# Replace newlines and double quotes in the schema
+SCHEMA=${SCHEMA//$'\n'/\\n}
+SCHEMA=${SCHEMA//\"/\\\"}
+
+# Register the schema with the Confluent Schema Registry
+curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+  --data "{\"schema\": \"${SCHEMA}\"}" \
+  http://$SCHEMA_REGISTRY_URL/subjects/${TOPIC_NAME}/versions

--- a/plugins/ca-kafka-local/plugin.json
+++ b/plugins/ca-kafka-local/plugin.json
@@ -20,6 +20,7 @@
   },
   "create_files": {
     "{{.Virtenv}}/bin/kafka-local-readme": "bin/kafka-local-readme",
+    "{{.Virtenv}}/bin/kafka-local-register-schema": "bin/kafka-local-register-schema",
     "{{.Virtenv}}/bin/kaf": "bin/kaf",
     "{{.Virtenv}}/config/process-compose.yaml": "config/process-compose.yaml",
     "{{.Virtenv}}/config/kafkactl/config.yaml.template": "config/kafkactl/config.yaml",


### PR DESCRIPTION
## Purpose

Give teams an easy way to register an Avro schema with Schema Registry.

This is meant to be a small developer experience improvement for teams that need it, with the long term goal being to add schemas from kafka-ops resources.

Jira: https://cultureamp.atlassian.net/browse/FEF-1557

## Changes

- Adds a basic shell script to register a schema with a curl command to schema registry
- Add docs for this script
- Update hotel commands to use the `up kafka` alias rather than `up kafka-local` (see https://github.com/cultureamp/hotel/pull/80)
