### PR TITLE
add jmx script to run_debezium wrapper script [DASE-1982]

### DIFF
--- a/packages/debezium-server.nix
+++ b/packages/debezium-server.nix
@@ -24,7 +24,7 @@ in
       mkdir -p $out/bin
       cat >$out/bin/run_debezium <<EOF
       #!$SHELL
-      RUNNER=\$(ls $out/debezium-server-*-runner.jar)
+      RUNNER="$out/debezium-server-dist-${version}-runner.jar"
       LIB_PATH="$out/lib/*"
 
       source $out/jmx/enable_jmx.sh


### PR DESCRIPTION
# Context

We are missing JMX support from the `run_debezium` wrapper script as part of our debezium-server nix package.  This changes the wrapper script to source the required JMX script, so JMX is enabled if JMX_HOST and JMX_PORT are provided

# Changes

- Source the jmx_enable.sh bash script