### PR TITLE
fix postgres version check

### DIFF
--- a/plugins/debezium-server/config/process-compose.yaml
+++ b/plugins/debezium-server/config/process-compose.yaml
@@ -15,14 +15,14 @@ processes:
   init_outbox:
     command: devbox run init_outbox
     depends_on:
-      postgres-invariant-checks:
+      postgres_invariant_checks:
         condition: process_completed_successfully
 
-  postgres-invariant-checks:
+  postgres_invariant_checks:
     command: devbox run postgres-version-check
 
   debezium_server:
-    working_dir: { { .Virtenv } }
+    working_dir: {{.Virtenv}}
     command: run_debezium
     depends_on:
       init_outbox:

--- a/plugins/debezium-server/plugin.json
+++ b/plugins/debezium-server/plugin.json
@@ -5,7 +5,7 @@
   "packages": [
     "nodejs@22.4.1",
     "pnpm@9.7.0",
-    "github:cultureamp/devbox-extras/debezium-server-plugin#debezium-server"
+    "github:cultureamp/devbox-extras#debezium-server"
   ],
   "env": {
     "DEVBOX_COREPACK_ENABLED": "true",

--- a/plugins/debezium-server/plugin.json
+++ b/plugins/debezium-server/plugin.json
@@ -70,6 +70,7 @@
     "{{.Virtenv}}/application.properties": "config/debezium-server/application.properties",
     "{{.Virtenv}}/init_outbox.sql": "config/debezium-server/init_outbox.sql",
     "{{.Virtenv}}/bin/debezium-server-readme": "bin/debezium-server-readme",
+    "{{.Virtenv}}/bin/postgres-version-check": "bin/postgres-version-check",
     "{{.Virtenv}}/package.json": "config/populate/package.json",
     "{{.Virtenv}}/tsconfig.json": "config/populate/tsconfig.json",
     "{{.Virtenv}}/sample-data.json": "config/populate/sample-data.json",


### PR DESCRIPTION
# Context

The various `devbox services` commands were failing due to the process-compose.yaml

# Changes

- Fix `working_dir`
- Update service naming convention to underscores, matching other services
- Ensure postgres-version-check binary is copied across on plugin install