### PR TITLE
Add basic script to tombstone offset and reset connector

### DIFF
--- a/plugins/debezium-server/plugin.json
+++ b/plugins/debezium-server/plugin.json
@@ -61,6 +61,16 @@
         "SAMPLE_DATA_PATH=sample-data.json \\",
         "pnpm run -C {{.Virtenv}} populate"
       ],
+      "reset_offset": [
+        "devbox services stop debezium_server && \\",
+        "PID=$(ps aux | grep '[i]o.debezium.server.Main' | awk '{print $2}' | head -n 1) && \\",
+        "[ -n \"$PID\" ] && timeout=0; while ps -p $PID > /dev/null && [ $timeout -lt 10 ]; do echo 'Waiting for debezium server to stop..'; sleep 1; ((timeout++)); done && \\",
+        "echo \"Tombstoning connector offset\"",
+        "echo \"[\\\"kafka\\\",{\\\"server\\\":\\\"${FARM}.${INTERNAL_TOPIC_PREFIX}\\\"}]|\" | \\",
+        "kcat -P -Z -b ${KAFKA_BROKERS_SASL} -X sasl.mechanism=PLAIN -X sasl.username=${KAFKA_SASL_USER} -X sasl.password=${KAFKA_SASL_PASSWORD} -t ${OFFSET_TOPIC} -K \\| -p 0 && \\",
+        "echo \"Restarting debezium server\" && \\",
+        "devbox services start debezium_server"
+      ],
       "debezium-server-readme": "{{.Virtenv}}/bin/debezium-server-readme",
       "postgres-version-check": "{{.Virtenv}}/bin/postgres-version-check"
     }


### PR DESCRIPTION
# Context

Given engineers are likely to run debezium server against a long living local kafka cluster and may wish to republish outbox table data, it is desirable to provide a means to reset the connector so a topic can be repopulated.

# Changes

Add a basic script to the debezium-server plugin that does the following:
1. stop debezium server
2. sends a tombstone to the offsets topic keyed on the internal topic prefix, effectively resetting the connector
3. restart debezium server