### PR TITLE
Add indefinite wait with readiness check to ensure postgres running

### DIFF
--- a/plugins/debezium-server/config/process-compose.yaml
+++ b/plugins/debezium-server/config/process-compose.yaml
@@ -17,6 +17,16 @@ processes:
     depends_on:
       postgres_invariant_checks:
         condition: process_completed_successfully
+      postgres_wait:
+        condition: process_healthy
+
+  postgres_wait:
+    command: "echo 'Waiting on postgresql...'; tail -f /dev/null"
+    readiness_probe:
+      period_seconds: 5
+      failure_threshold: 1000
+      exec:
+        command: pg_isready -U postgres
 
   postgres_invariant_checks:
     command: devbox run postgres-version-check


### PR DESCRIPTION
# Context

Sometimes, a project consuming the project may have a `postgresql` service with a dependency on another service, such as a `setup`.  This causes the `init_outbox` to immediately fail if postgres isn't ready.

Similar to the `kafka_local`, we create a `postgres_wait` service that will `tail` indefinitely, and has a 3 second readiness probe to confirm postgres is ready. Once ready, `init_outbox` can run successfully.

# Changes

Add `postgres_wait` service to check postgres is ready, and have `init_outbox` depend on this, so we don't attempt to setup postgres before ready.