### PR TITLE
Github App authentication

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         # See: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         # for the mapping of architecture to the runner type.
-        runs-on: [macos-13, macos-latest]
+        runs-on: [macos-13, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,8 @@ jobs:
       - name: run install script
         shell: bash
         run: |
-          HOTEL_INSTALL_GITHUB_TOKEN="${{ secrets.HOTEL_ACCESS_TOKEN }}" ./scripts/install_hotel.sh
+          security add-generic-password -a github.app -s com.cultureamp.hotel -w "${{ secrets.HOTEL_ACCESS_TOKEN }}" -U
+          ./scripts/install_hotel.sh
       - name: verify hotel executable is available and working
         shell: bash
         run: hotel --version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: run install script
         shell: bash
         run: |
-          GITHUB_TOKEN="${{ secrets.HOTEL_ACCESS_TOKEN }}" ./scripts/install_hotel.sh
+          HOTEL_INSTALL_GITHUB_TOKEN="${{ secrets.HOTEL_ACCESS_TOKEN }}" ./scripts/install_hotel.sh
       - name: verify hotel executable is available and working
         shell: bash
         run: hotel --version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,22 +39,19 @@ jobs:
       - uses: actions/checkout@v3
       - uses: jetify-com/devbox-install-action@v0.9.0
       - run: devbox run lint
-  e2e-install-hotel:
+  hotel-install-script:
     strategy:
       matrix:
         # See: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         # for the mapping of architecture to the runner type.
-        runs-on: [macos-13, macos-latest, ubuntu-latest] # TODO
+        runs-on: [macos-13, macos-latest]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
       - name: run install script
         shell: bash
         run: |
-          export HOTEL_INSTALLER_GITHUB_TOKEN="${{ secrets.HOTEL_ACCESS_TOKEN }}"
-          # this syntax should match what we recommend in the readme
-          export INSTALLER_URL="https://raw.githubusercontent.com/cultureamp/devbox-extras/$GITHUB_SHA/scripts/install_hotel.sh"
-          sh -c "$(curl -fsSL "$INSTALLER_URL")"
+          GITHUB_TOKEN="${{ secrets.HOTEL_ACCESS_TOKEN }}" ./scripts/install_hotel.sh
       - name: verify hotel executable is available and working
         shell: bash
         run: hotel --version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,8 +51,7 @@ jobs:
       - name: run install script
         shell: bash
         run: |
-          security add-generic-password -a github.app -s com.cultureamp.hotel -w "${{ secrets.HOTEL_ACCESS_TOKEN }}" -U
-          ./scripts/install_hotel.sh
+           ./scripts/install_hotel.sh "${{ secrets.HOTEL_ACCESS_TOKEN }}" 
       - name: verify hotel executable is available and working
         shell: bash
         run: hotel --version

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+# https://docs.rubocop.org/rubocop/configuration
+AllCops:
+  Exclude:
+    - ".devbox/**/*"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ ruby -e "$(curl -fsSL https://github.com/cultureamp/devbox-extras/blob/main/scri
 hotel setup ensure
 ```
 
+Should this authentication flow not work, you can manually authenticate with the following script:
+The PAT token should have read access to the `repository` scope and be enabled with SSO for Culture Amp.
+
+```bash
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/cultureamp/devbox-extras/main/scripts/install_hotel.sh) {insert_pat_token_here}"
+```
+
 # devbox-plugins
 
 Devbox is something we're trialing internally, we need some plugins. So putting them here for now, all in one place. Plugins are documented in their respective folders.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ hotel setup ensure
 ```
 
 Should this authentication flow not work, you can manually authenticate with the following script:
-The PAT token should have read access to the `repository` scope and be enabled with SSO for Culture Amp.
+The github token should have read access to the `repository` scope and be enabled with SSO for Culture Amp.
 
 ```bash
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/cultureamp/devbox-extras/main/scripts/install_hotel.sh) {insert_pat_token_here}"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The recommended command to setup a Culture Amp macbook for working with LDEs/dev
 
 ```bash
 # install hotel cli
-sh -c "$(curl -fsSL "https://raw.githubusercontent.com/cultureamp/devbox-extras/main/scripts/install_hotel.sh")"
+ruby -e "$(curl -fsSL https://github.com/cultureamp/devbox-extras/blob/main/scripts/github_auth.rb)"
 
 # use hotel to setup LDEs
 hotel setup ensure

--- a/devbox.json
+++ b/devbox.json
@@ -11,7 +11,8 @@
     "statix",
     "shellcheck",
     "shfmt",
-    "nodePackages.prettier"
+    "nodePackages.prettier",
+    "rubocop@latest"
   ],
   "shell": {
     "scripts": {
@@ -21,13 +22,15 @@
         "shellcheck **/*.{sh,bats} &",
         "shfmt --diff **/*.{sh,bats} &",
         "prettier . --check &",
+        "rubocop &",
         "wait"
       ],
       "lint:fix": [
         "nixpkgs-fmt .",
         "statix fix --ignore .devbox",
         "shfmt --write **/*.{sh,bats}",
-        "prettier . --write"
+        "prettier . --write",
+        "rubocop --autocorrect"
       ],
       "test": [
         "devbox run test-bash",

--- a/devbox.lock
+++ b/devbox.lock
@@ -21,6 +21,54 @@
       "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#nodePackages.prettier",
       "source": "nixpkg"
     },
+    "rubocop@latest": {
+      "last_modified": "2024-08-31T19:22:30Z",
+      "resolved": "github:NixOS/nixpkgs/282e35e0762d64800d78e33ff225704baf9e5216#rubocop",
+      "source": "devbox-search",
+      "version": "1.65.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/f7mjcpgy4kac87ygnwrc8zss4ps67x1w-ruby3.3-rubocop-1.65.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/f7mjcpgy4kac87ygnwrc8zss4ps67x1w-ruby3.3-rubocop-1.65.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ls69blqq10hqadgn99v02qhdzfs99jkk-ruby3.3-rubocop-1.65.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ls69blqq10hqadgn99v02qhdzfs99jkk-ruby3.3-rubocop-1.65.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/xri9m3wj2zq4bwsszc9bkcn38664nl66-ruby3.3-rubocop-1.65.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/xri9m3wj2zq4bwsszc9bkcn38664nl66-ruby3.3-rubocop-1.65.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/358ycw2rdmyr26rxsxsszhsyfmxps29b-ruby3.3-rubocop-1.65.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/358ycw2rdmyr26rxsxsszhsyfmxps29b-ruby3.3-rubocop-1.65.1"
+        }
+      }
+    },
     "shellcheck": {
       "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#shellcheck",
       "source": "nixpkg"

--- a/scripts/github_auth.rb
+++ b/scripts/github_auth.rb
@@ -6,7 +6,7 @@ require 'json'
 require 'uri'
 require 'fileutils'
 
-CLIENT_ID="Iv23liPv59QtSVurh6Fk"
+CLIENT_ID = 'Iv23liPv59QtSVurh6Fk'
 
 def parse_response(response)
   case response
@@ -67,9 +67,8 @@ def poll_for_token(device_code, interval)
         exit 1
       end
     else
-      return [access_token, refresh_token]
+      return [access_token, refresh_token] unless error
     end
-    break
   end
 end
 # rubocop:enable Metrics/MethodLength
@@ -96,7 +95,10 @@ def main
     puts 'currently this script only supports MacOS'
     exit 1
   end
-  verification_uri, user_code, device_code, interval = request_device_code.values_at('verification_uri', 'user_code', 'device_code', 'interval')
+  verification_uri, user_code, device_code, interval = request_device_code.values_at('verification_uri',
+                                                                                     'user_code',
+                                                                                     'device_code',
+                                                                                     'interval')
 
   puts "Please visit: #{verification_uri} and enter the following code: #{user_code}"
 

--- a/scripts/github_auth.rb
+++ b/scripts/github_auth.rb
@@ -6,7 +6,7 @@ require 'json'
 require 'uri'
 require 'fileutils'
 
-CLIENT_ID = ENV['GITHUB_APP_CLIENT_ID']
+CLIENT_ID="Iv23liPv59QtSVurh6Fk"
 
 def parse_response(response)
   case response
@@ -96,12 +96,7 @@ def main
     puts 'currently this script only supports MacOS'
     exit 1
   end
-  if CLIENT_ID.nil?
-    puts 'Please set the GITHUB_APP_CLIENT_ID environment variable.'
-    exit 1
-  end
-  verification_uri, user_code, device_code, interval = request_device_code.values_at('verification_uri', 'user_code',
-                                                                                     'device_code', 'interval')
+  verification_uri, user_code, device_code, interval = request_device_code.values_at('verification_uri', 'user_code', 'device_code', 'interval')
 
   puts "Please visit: #{verification_uri} and enter the following code: #{user_code}"
 

--- a/scripts/github_auth.rb
+++ b/scripts/github_auth.rb
@@ -104,7 +104,7 @@ def main
 
   set_tokens(access_token, refresh_token)
 
-  `./scripts/install_hotel.sh`
+  `sh -c "$(curl -fsSL https://raw.githubusercontent.com/cultureamp/devbox-extras/main/scripts/install_hotel.sh)"`
 end
 # rubocop:enable Metrics/MethodLength
 

--- a/scripts/install_hotel.rb
+++ b/scripts/install_hotel.rb
@@ -1,0 +1,142 @@
+#!/usr/bin/env ruby
+
+require "net/http"
+require "json"
+require "uri"
+require "fileutils"
+
+CLIENT_ID = ENV["GITHUB_APP_CLIENT_ID"]
+
+def help
+  puts "usage: app_cli <login | whoami | help>"
+end
+
+def main
+  case ARGV[0]
+  when "help"
+    help
+  when "login"
+    login
+  when "whoami"
+    whoami
+  else
+    puts "Unknown command #{ARGV[0]}"
+  end
+end
+
+def parse_response(response)
+  case response
+  when Net::HTTPOK, Net::HTTPCreated
+    JSON.parse(response.body)
+  when Net::HTTPUnauthorized
+    puts "You are not authorized. Run the `login` command."
+    exit 1
+  else
+    puts response
+    puts response.body
+    exit 1
+  end
+end
+
+def request_device_code
+  uri = URI("https://github.com/login/device/code")
+  parameters = URI.encode_www_form("client_id" => CLIENT_ID)
+  headers = {"Accept" => "application/json"}
+
+  response = Net::HTTP.post(uri, parameters, headers)
+  parse_response(response)
+end
+
+def request_token(device_code)
+  uri = URI("https://github.com/login/oauth/access_token")
+  parameters = URI.encode_www_form({
+    "client_id" => CLIENT_ID,
+    "device_code" => device_code,
+    "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+  })
+  headers = {"Accept" => "application/json"}
+  response = Net::HTTP.post(uri, parameters, headers)
+  parse_response(response)
+end
+
+def poll_for_token(device_code, interval)
+
+  loop do
+    response = request_token(device_code)
+    error, access_token = response.values_at("error", "access_token")
+
+    if error
+      case error
+      when "authorization_pending"
+        # The user has not yet entered the code.
+        # Wait, then poll again.
+        sleep interval
+        next
+      when "slow_down"
+        # The app polled too fast.
+        # Wait for the interval plus 5 seconds, then poll again.
+        sleep interval + 5
+        next
+      when "expired_token"
+        # The `device_code` expired, and the process needs to restart.
+        puts "The device code has expired. Please run `login` again."
+        exit 1
+      when "access_denied"
+        # The user cancelled the process. Stop polling.
+        puts "Login cancelled by user."
+        exit 1
+      else
+        puts response
+        exit 1
+      end
+    end
+
+    osName = `uname -s`
+    if osName == "Darwin\n"
+      `security add-generic-password -a "github" -s "com.tmonaghan.hello-world" -w "#{access_token}" -U`
+    else
+      # hotel_secrets_path = "#{ENV['XDG_DATA_DIR'] || "#{Dir.home}/.local/share"}/hotel/secrets"
+      # Dir.mkdir(hotel_secrets_path)
+      # File.write(hotel_secrets_path + "/" + "github", access_token)
+      # FileUtils.chmod(0600, "./.token")
+    end
+
+    break
+  end
+end
+
+def login
+  verification_uri, user_code, device_code, interval = request_device_code.values_at("verification_uri", "user_code", "device_code", "interval")
+
+  # puts "Please visit: #{verification_uri}"
+  `open #{verification_uri}`
+  puts "A browser window should appear, please authorise the : #{user_code}"
+
+  poll_for_token(device_code, interval)
+
+  puts "Successfully authenticated!"
+end
+
+def whoami
+  uri = URI("https://api.github.com/user")
+
+  begin
+    # token = File.read("./.token").strip
+    token = `security find-generic-password -a "github" -s "com.tmonaghan.hello-world" -w`.strip
+  rescue Errno::ENOENT => e
+    puts "You are not authorized. Run the `login` command."
+    exit 1
+  end
+
+  response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+    body = {"access_token" => token}.to_json
+    headers = {"Accept" => "application/vnd.github+json", "Authorization" => "Bearer #{token}"}
+
+    http.send_request("GET", uri.path, body, headers)
+  end
+
+  parsed_response = parse_response(response)
+  puts "You are #{parsed_response["login"]}"
+end
+
+main

--- a/scripts/install_hotel.rb
+++ b/scripts/install_hotel.rb
@@ -1,142 +1,120 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require "net/http"
-require "json"
-require "uri"
-require "fileutils"
+require 'net/http'
+require 'json'
+require 'uri'
+require 'fileutils'
 
-CLIENT_ID = ENV["GITHUB_APP_CLIENT_ID"]
-
-def help
-  puts "usage: app_cli <login | whoami | help>"
-end
-
-def main
-  case ARGV[0]
-  when "help"
-    help
-  when "login"
-    login
-  when "whoami"
-    whoami
-  else
-    puts "Unknown command #{ARGV[0]}"
-  end
-end
+CLIENT_ID = ENV['GITHUB_APP_CLIENT_ID']
 
 def parse_response(response)
   case response
   when Net::HTTPOK, Net::HTTPCreated
     JSON.parse(response.body)
   when Net::HTTPUnauthorized
-    puts "You are not authorized. Run the `login` command."
+    puts 'You are not authorized. Run the `login` command.'
     exit 1
   else
-    puts response
-    puts response.body
+    puts "An error occurred: #{response.code} #{response.message}"
     exit 1
   end
 end
 
 def request_device_code
-  uri = URI("https://github.com/login/device/code")
-  parameters = URI.encode_www_form("client_id" => CLIENT_ID)
-  headers = {"Accept" => "application/json"}
+  uri = URI('https://github.com/login/device/code')
+  parameters = URI.encode_www_form('client_id' => CLIENT_ID)
+  headers = { 'Accept' => 'application/json' }
 
   response = Net::HTTP.post(uri, parameters, headers)
   parse_response(response)
 end
 
 def request_token(device_code)
-  uri = URI("https://github.com/login/oauth/access_token")
+  uri = URI('https://github.com/login/oauth/access_token')
   parameters = URI.encode_www_form({
-    "client_id" => CLIENT_ID,
-    "device_code" => device_code,
-    "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
-  })
-  headers = {"Accept" => "application/json"}
+                                     'client_id' => CLIENT_ID,
+                                     'device_code' => device_code,
+                                     'grant_type' => 'urn:ietf:params:oauth:grant-type:device_code'
+                                   })
+  headers = { 'Accept' => 'application/json' }
   response = Net::HTTP.post(uri, parameters, headers)
   parse_response(response)
 end
+# rubocop:disable Metrics/MethodLength
 
 def poll_for_token(device_code, interval)
-
   loop do
     response = request_token(device_code)
-    error, access_token = response.values_at("error", "access_token")
+    error, access_token, refresh_token = response.values_at('error', 'access_token', 'refresh_token')
 
     if error
       case error
-      when "authorization_pending"
+      when 'authorization_pending'
         # The user has not yet entered the code.
         # Wait, then poll again.
         sleep interval
         next
-      when "slow_down"
+      when 'slow_down'
         # The app polled too fast.
         # Wait for the interval plus 5 seconds, then poll again.
         sleep interval + 5
         next
-      when "expired_token"
+      when 'expired_token'
         # The `device_code` expired, and the process needs to restart.
-        puts "The device code has expired. Please run `login` again."
+        puts 'The device code has expired. Please run `login` again.'
         exit 1
-      when "access_denied"
+      when 'access_denied'
         # The user cancelled the process. Stop polling.
-        puts "Login cancelled by user."
+        puts 'Login cancelled by user.'
         exit 1
       else
         puts response
         exit 1
       end
-    end
-
-    osName = `uname -s`
-    if osName == "Darwin\n"
-      `security add-generic-password -a "github" -s "com.tmonaghan.hello-world" -w "#{access_token}" -U`
     else
-      # hotel_secrets_path = "#{ENV['XDG_DATA_DIR'] || "#{Dir.home}/.local/share"}/hotel/secrets"
-      # Dir.mkdir(hotel_secrets_path)
-      # File.write(hotel_secrets_path + "/" + "github", access_token)
-      # FileUtils.chmod(0600, "./.token")
+      set_tokens(access_token, refresh_token)
     end
-
     break
   end
 end
+# rubocop:enable Metrics/MethodLength
 
-def login
-  verification_uri, user_code, device_code, interval = request_device_code.values_at("verification_uri", "user_code", "device_code", "interval")
+APP_SERVICE_NAME = 'com.cultureamp.hotel'
+APP_ACCOUNT_NAME = 'github.app'
 
-  # puts "Please visit: #{verification_uri}"
-  `open #{verification_uri}`
-  puts "A browser window should appear, please authorise the : #{user_code}"
+def set_tokens(access_token, refresh_token)
+  add_keychain_item(APP_SERVICE_NAME, APP_ACCOUNT_NAME, access_token)
+  add_keychain_item("#{APP_SERVICE_NAME}.refresh", APP_ACCOUNT_NAME, refresh_token)
+end
+
+def add_keychain_item(service_name, account_name, password)
+  `security add-generic-password -a #{account_name} -s #{service_name} -w #{password} -U`
+rescue StandardError => e
+  puts "An error occurred while setting a token in the keychain: #{e.message}"
+  exit 1
+end
+
+# rubocop:disable Metrics/MethodLength
+def main
+  os_name = `uname -s`
+  if os_name != "Darwin\n"
+    puts 'currently this script only supports MacOS'
+    exit 1
+  end
+  if CLIENT_ID.nil?
+    puts 'Please set the GITHUB_APP_CLIENT_ID environment variable.'
+    exit 1
+  end
+  verification_uri, user_code, device_code, interval = request_device_code.values_at('verification_uri', 'user_code',
+                                                                                     'device_code', 'interval')
+
+  puts "Please visit: #{verification_uri} and enter the following code: #{user_code}"
 
   poll_for_token(device_code, interval)
 
-  puts "Successfully authenticated!"
+  puts 'Successfully authenticated!'
 end
-
-def whoami
-  uri = URI("https://api.github.com/user")
-
-  begin
-    # token = File.read("./.token").strip
-    token = `security find-generic-password -a "github" -s "com.tmonaghan.hello-world" -w`.strip
-  rescue Errno::ENOENT => e
-    puts "You are not authorized. Run the `login` command."
-    exit 1
-  end
-
-  response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
-    body = {"access_token" => token}.to_json
-    headers = {"Accept" => "application/vnd.github+json", "Authorization" => "Bearer #{token}"}
-
-    http.send_request("GET", uri.path, body, headers)
-  end
-
-  parsed_response = parse_response(response)
-  puts "You are #{parsed_response["login"]}"
-end
+# rubocop:enable Metrics/MethodLength
 
 main

--- a/scripts/install_hotel.sh
+++ b/scripts/install_hotel.sh
@@ -23,7 +23,7 @@ logRed() {
 }
 
 download_latest_hotel() {
-  if [ -z "$1" ]; then
+  if [ -n "$1" ]; then
       github_token="$1"
   else
       github_token="$(security find-generic-password -s "com.cultureamp.hotel" -a github.app -w)"

--- a/scripts/install_hotel.sh
+++ b/scripts/install_hotel.sh
@@ -23,10 +23,10 @@ logRed() {
 }
 
 download_latest_hotel() {
-	if [[ "$(uname)" == "Darwin" ]]; then
-		github_token="$(security find-generic-password -s "com.cultureamp.hotel" -a github.app -w)"
+    if [ -z "$HOTEL_INSTALL_GITHUB_TOKEN" ]; then
+        github_token=$HOTEL_INSTALL_GITHUB_TOKEN
     else
-		github_token="$GITHUB_TOKEN"
+        github_token="$(security find-generic-password -s "com.cultureamp.hotel" -a github.app -w)"
     fi
 
 	if [ -z "$github_token" ]; then

--- a/scripts/install_hotel.sh
+++ b/scripts/install_hotel.sh
@@ -12,126 +12,85 @@ mkdir -p "$receipt_log_dir"
 # this file does a log of echo-ing strings for use by calling function, logs
 # intended for the user should always go to stderr - these functions makes it easier
 log() {
-  >&2 echo "$@"
-  echo "$@" >>"$receipt_log_file"
+	echo >&2 "$@"
+	echo "$@" >>"$receipt_log_file"
 }
 logRed() {
-  >&2 printf "\033[31m" # red
-  >&2 echo "$@"
-  >&2 printf "\033[0m" # reset
-  echo "$@" >>"$receipt_log_file"
-}
-
-service_name="com.cultureamp.hotel"
-account_name="github"
-hotel_secrets_path="${XDG_DATA_DIR:-$HOME/.local/share}/hotel/secrets"
-
-store_github_token() {
-  new_password="$1"
-  if [ "$(uname)" = "Darwin" ]; then
-    # on macos use the built in secrets manager as this is usually real hardware
-    if security find-generic-password -s "$service_name" -a "$account_name" >/dev/null 2>&1; then
-      security delete-generic-password -s "$service_name" -a "$account_name" >/dev/null 2>&1 # remove if exists so write doesn't fail
-    fi
-    security add-generic-password -s "$service_name" -a "$account_name" -w "$new_password"
-  else
-    # other OSs may or may not have a keyring, are likely a container or VM so secrets handling is less of a concern
-    # also it's difficult to setup a keyring in a linux container (https://unix.stackexchange.com/a/548005)
-    mkdir -p "$hotel_secrets_path"
-    echo "$new_password" >"$hotel_secrets_path/$account_name"
-  fi
-}
-
-get_and_store_github_key() {
-  if [ -n "$HOTEL_INSTALLER_GITHUB_TOKEN" ]; then
-    # github_token can be provided as env var (used in scripts to avoid prompt)
-    github_token="$HOTEL_INSTALLER_GITHUB_TOKEN"
-  else
-    log ""
-    log "We need a github key to download hotel, and for hotel to use to pull git repos"
-    log "It will be stored in the system keychain"
-    log ""
-    log "You can generate a token here:"
-    log "    https://github.com/settings/tokens/new?scopes=repo "
-    log ""
-    logRed "The token MUST have CultureAmp SSO configured or this script WILL FAIL"
-    log ""
-    # no token found, ask user
-    read -s -r -p "Github token: " github_token
-  fi
-
-  store_github_token "$github_token"
-  echo "$github_token"
+	printf >&2 "\033[31m" # red
+	echo >&2 "$@"
+	printf >&2 "\033[0m" # reset
+	echo "$@" >>"$receipt_log_file"
 }
 
 download_latest_hotel() {
-  github_token="$1"
-  if [ -z "$github_token" ]; then
-    log "github_token missing"
-    exit 1
-  fi
+	github_token="$(security find-generic-password -s "com.cultureamp.hotel" -a github.app -w)"
+	if [ -z "$github_token" ]; then
+		log ""
+		logRed "Github token not found. Please ensure it is correctly set."
+		log ""
+		exit 1
+	fi
 
-  releases_file="$(mktemp)"
-  # set the output flag to write reponse to json and write out flag to write response code to stdout
-  # this allows us to get them separately from one request without having to parse anything
-  response_code="$(
-    curl -sL https://api.github.com/repos/cultureamp/hotel/releases/latest \
-      --user "_:$github_token" \
-      --output "$releases_file" \
-      --write-out "%{http_code}" \
-      --header "Accept: application/json"
-  )"
-  if [ "$response_code" != "200" ]; then
-    log ""
-    logRed "Could not get latest hotel release from github. This is likely because your github token is invalid."
-    log ""
-    log "Ensure you have enabled SSO on the token, and entered it correctly"
-    exit 1
-  fi
-  releases_json="$(cat "$releases_file")"
-  rm "$releases_file"
+	releases_file="$(mktemp)"
+	# set the output flag to write reponse to json and write out flag to write response code to stdout
+	# this allows us to get them separately from one request without having to parse anything
+	response_code="$(
+		curl -sL https://api.github.com/repos/cultureamp/hotel/releases/latest \
+			--user "_:$github_token" \
+			--output "$releases_file" \
+			--write-out "%{http_code}" \
+			--header "Accept: application/json"
+	)"
+	if [ "$response_code" != "200" ]; then
+		log ""
+		logRed "Could not get latest hotel release from github. This is likely because your github token is invalid."
+		log ""
+		log "Ensure you have enabled SSO on the token, and entered it correctly"
+		exit 1
+	fi
+	releases_json="$(cat "$releases_file")"
+	rm "$releases_file"
 
-  # we can't get the specific release we want without a json parsing tool, so we get all
-  # download links and download until we find the one matching the system's arch and os
-  release_asset_urls=$(echo "$releases_json" |
-    grep '"url": ".*/releases/assets/.*"' |
-    cut -d\" -f4)
+	# we can't get the specific release we want without a json parsing tool, so we get all
+	# download links and download until we find the one matching the system's arch and os
+	release_asset_urls=$(echo "$releases_json" |
+		grep '"url": ".*/releases/assets/.*"' |
+		cut -d\" -f4)
 
-  for url in $release_asset_urls; do
-    # the only way to get a release's file name is to download it and write-out the filename
-    downloaded_file=$(
-      curl -sL "$url" \
-        --user "_:$github_token" \
-        --remote-header-name --remote-name \
-        --write-out "%{filename_effective}" \
-        --header "Accept: application/octet-stream"
-    )
-    if [ "$downloaded_file" = "$hotel_tarball_name" ]; then
-      tar -xzf "$downloaded_file"
-      return
-    else
-      rm "$downloaded_file"
-    fi
-  done
+	for url in $release_asset_urls; do
+		# the only way to get a release's file name is to download it and write-out the filename
+		downloaded_file=$(
+			curl -sL "$url" \
+				--user "_:$github_token" \
+				--remote-header-name --remote-name \
+				--write-out "%{filename_effective}" \
+				--header "Accept: application/octet-stream"
+		)
+		if [ "$downloaded_file" = "$hotel_tarball_name" ]; then
+			tar -xzf "$downloaded_file"
+			return
+		else
+			rm "$downloaded_file"
+		fi
+	done
 }
 
 install_hotel() {
-  log "=> downloading hotel binary..."
-  INITIAL_DIR="$PWD"
-  TMPDIR=$(mktemp -d)
-  cd "$TMPDIR"
-  download_latest_hotel "$1"
-  mkdir -p "$hotel_bin_path/"
-  mv hotel "$hotel_bin_path"
-  cd "$INITIAL_DIR"
-  rm -rf "$TMPDIR"
-  log "=> installing hotel, this will ask for a sudo password"
-  sudo "$hotel_bin_path/hotel" setup launcher
+	log "=> downloading hotel binary..."
+	INITIAL_DIR="$PWD"
+	TMPDIR=$(mktemp -d)
+	cd "$TMPDIR"
+	download_latest_hotel "$1"
+	mkdir -p "$hotel_bin_path/"
+	mv hotel "$hotel_bin_path"
+	cd "$INITIAL_DIR"
+	rm -rf "$TMPDIR"
+	log "=> installing hotel, this will ask for a sudo password"
+	sudo "$hotel_bin_path/hotel" setup launcher
 }
 
 main() {
-  github_token=$(get_and_store_github_key)
-  install_hotel "$github_token"
+	install_hotel
 }
 
 main

--- a/scripts/install_hotel.sh
+++ b/scripts/install_hotel.sh
@@ -23,11 +23,11 @@ logRed() {
 }
 
 download_latest_hotel() {
-    if [ -z "$HOTEL_INSTALL_GITHUB_TOKEN" ]; then
-        github_token=$HOTEL_INSTALL_GITHUB_TOKEN
-    else
-        github_token="$(security find-generic-password -s "com.cultureamp.hotel" -a github.app -w)"
-    fi
+  if [ -z "$1" ]; then
+      github_token="$1"
+  else
+      github_token="$(security find-generic-password -s "com.cultureamp.hotel" -a github.app -w)"
+  fi
 
 	if [ -z "$github_token" ]; then
 		log ""

--- a/scripts/install_hotel.sh
+++ b/scripts/install_hotel.sh
@@ -23,12 +23,6 @@ logRed() {
 }
 
 download_latest_hotel() {
-  if [ -n "$1" ]; then
-      github_token="$1"
-  else
-      github_token="$(security find-generic-password -s "com.cultureamp.hotel" -a github.app -w)"
-  fi
-
 	if [ -z "$github_token" ]; then
 		log ""
 		logRed "Github token not found. Please ensure it is correctly set."
@@ -85,7 +79,7 @@ install_hotel() {
 	INITIAL_DIR="$PWD"
 	TMPDIR=$(mktemp -d)
 	cd "$TMPDIR"
-	download_latest_hotel "$1"
+	download_latest_hotel 
 	mkdir -p "$hotel_bin_path/"
 	mv hotel "$hotel_bin_path"
 	cd "$INITIAL_DIR"
@@ -95,7 +89,13 @@ install_hotel() {
 }
 
 main() {
-	install_hotel
+  if [ -n "$1" ]; then
+      github_token="$1"
+  else
+      github_token="$(security find-generic-password -s "com.cultureamp.hotel" -a github.app -w)"
+  fi
+
+	install_hotel 
 }
 
-main
+main "$@"

--- a/scripts/install_hotel.sh
+++ b/scripts/install_hotel.sh
@@ -23,7 +23,12 @@ logRed() {
 }
 
 download_latest_hotel() {
-	github_token="$(security find-generic-password -s "com.cultureamp.hotel" -a github.app -w)"
+	if [[ "$(uname)" == "Darwin" ]]; then
+		github_token="$(security find-generic-password -s "com.cultureamp.hotel" -a github.app -w)"
+    else
+		github_token="$GITHUB_TOKEN"
+    fi
+
 	if [ -z "$github_token" ]; then
 		log ""
 		logRed "Github token not found. Please ensure it is correctly set."


### PR DESCRIPTION
### Summary

`hotel` is now using Github app authentication. This PR is intending to have the install flow for  `hotel` use this same authentication flow, and set up the tokens ready for `hotel` to consume.

### Changes

The end-to-end test has been removed and replaced with a test of the install script. The authentication is unable to be tested as it requires interaction with the browser, however the functions of the install are still tested, and should authentication break we are still able to override with PAT tokens.

### Test the new install command

`ruby -e "$(curl -fsSL https://raw.githubusercontent.com/cultureamp/devbox-extras/tfm/fef-1572-gh-auth/scripts/github_auth.rb)"`

### Test the fallback command
`sh -c "$(curl -fsSL https://raw.githubusercontent.com/cultureamp/devbox-extras/main/scripts/install_hotel.sh) {insert_pat_token_here}"`