### PR TITLE
Allow custom schema and data file paths, print file path on registering

### DIFF
--- a/plugins/debezium-server/bin/populate.ts
+++ b/plugins/debezium-server/bin/populate.ts
@@ -44,7 +44,7 @@ const registerSchema = async () => {
     type: SchemaType.AVRO,
     schema,
   });
-  console.log(`Auto-registered schema with id ${id}`);
+  console.log(`Auto-registered schema ${schemaPath} with id ${id}`);
 
   return id;
 };

--- a/plugins/debezium-server/plugin.json
+++ b/plugins/debezium-server/plugin.json
@@ -35,6 +35,8 @@
       "export OUTBOX_TABLE=outbox_table",
       "export HEARTBEAT_TABLE=debezium_heartbeat",
       "export TARGET_TOPIC=my_target_topic",
+      "export SCHEMA_PATH=com.cultureamp.test.user.v1-value.avsc",
+      "export SAMPLE_DATA_PATH=sample-data.json",
       "pnpm install -C {{.Virtenv}}"
     ],
     "scripts": {
@@ -57,8 +59,6 @@
         "kaf topic create _${FARM}.${INTERNAL_TOPIC_PREFIX}.debezium-heartbeat-table -p 1 -r 1 || true"
       ],
       "populate": [
-        "SCHEMA_PATH=com.cultureamp.test.user.v1-value.avsc \\",
-        "SAMPLE_DATA_PATH=sample-data.json \\",
         "pnpm run -C {{.Virtenv}} populate"
       ],
       "reset_offset": [


### PR DESCRIPTION
# Context

We currently provide an Avro schema file and sample data JSON that will allow users to run `devbox run populate`, resulting in Avro-encoded payloads being published to the outbox table.

However, the environment variables for these are hard-coded, and cannot be overridden

# Changes

- Set relevant environment variables as export in `init_hook`, so users can override and register their own schema plus publish their own data
- Print out the schema file path when registering against schema registry