### PR TITLE
only write to config when using PAT

### DIFF
--- a/scripts/install_hotel.sh
+++ b/scripts/install_hotel.sh
@@ -84,7 +84,7 @@ install_hotel() {
 	mv hotel "$hotel_bin_path"
 	cd "$INITIAL_DIR"
 	rm -rf "$TMPDIR"
-	if [ -n "$github_token" ]; then
+	if [ "$using_pat" = "true" ]; then
 		mkdir -p ~/.config/hotel
 		touch ~/.config/hotel/config.yaml
 		echo "github.token: $github_token" >> ~/.config/hotel/config.yaml
@@ -96,6 +96,7 @@ install_hotel() {
 main() {
   if [ -n "$1" ]; then
       github_token="$1"
+      using_pat="true"
   else
       github_token="$(security find-generic-password -s "com.cultureamp.hotel" -a github.app -w)"
   fi


### PR DESCRIPTION
### Summary

In order to make CI able to install hotel we write a token to a config file. However the behaviour I wrote for this was always writing to a config file whether being installed in CI or on a developer's machine.

### Changes

A new variable has been introduced to check if we are using a PAT, and if so the install script will write to file. Previously we were checking if a variable containing the token existed, however this variable always existed.

#### PR that introduced this bug

https://github.com/cultureamp/devbox-extras/pull/51