### PR TITLE
Database environment variable fixes for Debezium Server

### DIFF
--- a/plugins/debezium-server/bin/populate.ts
+++ b/plugins/debezium-server/bin/populate.ts
@@ -16,7 +16,7 @@ const targetTopic = process.env.TARGET_TOPIC;
 
 // Postgres source configuration
 const dbSchema = process.env.DB_SCHEMA;
-const dbHost = process.env.DB_HOST;
+const dbHost = process.env.DB_HOSTNAME;
 const dbPort = parseInt(process.env.DB_PORT);
 const dbName = process.env.DB_NAME;
 const dbUsername = process.env.DB_USERNAME;

--- a/plugins/debezium-server/plugin.json
+++ b/plugins/debezium-server/plugin.json
@@ -18,7 +18,7 @@
       "export PATH=$VENV_DIR/bin:$PATH",
       "export DEVBOX_DIR=$VENV_DIR",
       "export DB_HOSTNAME=localhost",
-      "export DB_PORT=5432",
+      "export DB_PORT=${PGPORT:-5432}",
       "export DB_AUTH_USERNAME=postgres",
       "export DB_AUTH_PASSWORD=postgres",
       "export DB_USERNAME=dbz_user",


### PR DESCRIPTION
# Context

There are a couple of fixes / changes to apply for the Debezium Server DevBox plugin surrounding environment variable usage

# Changes

- The database host should be `DB_HOSTNAME` in the populate script, not `DB_HOST`
- We default the `DB_PORT` to `PGPORT` where it exists with `5432` (the postgres default) as a fallback.  Some teams were overriding `PGPORT` and were not also updating `DB_PORT` at the same time, which was confusing