### PR TITLE
Add '-value' suffix to schema name in schema registration script.

### DIFF
--- a/plugins/ca-kafka-local/bin/kafka-local-register-schema
+++ b/plugins/ca-kafka-local/bin/kafka-local-register-schema
@@ -28,4 +28,4 @@ SCHEMA=${SCHEMA//\"/\\\"}
 # Register the schema with the Confluent Schema Registry
 curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
   --data "{\"schema\": \"${SCHEMA}\"}" \
-  $SCHEMA_REGISTRY_URL/subjects/${TOPIC_NAME}/versions
+  $SCHEMA_REGISTRY_URL/subjects/${TOPIC_NAME}-value/versions


### PR DESCRIPTION
## Purpose
Updates the `kafka-local-register-schema` script to add the `-value` suffix to the schema name. This is to ensure that message values can be serialised using avro when publishing data to a particular topic.

### Notes
Before change:
<img width="428" alt="image" src="https://github.com/user-attachments/assets/db956c72-d06a-4a9c-8458-f0662b7002cd">

After change:
<img width="388" alt="image" src="https://github.com/user-attachments/assets/35607629-0768-4e81-8c1e-bdfce196a283">
