### PR TITLE
introduces ca-changesets plugin

### DIFF
--- a/plugins/ca-changesets/README.md
+++ b/plugins/ca-changesets/README.md
@@ -1,0 +1,13 @@
+ca-changesets is a devbox plugin that acts as a thin wrapper around the npm package [changesets](https://changesets-docs.vercel.app/).
+
+This is provided so that any non-JS projects can make use of the `changeset` binary without managing `node` or a `node_modules/` directory.
+
+To include changesets in your project, add the following to the top level of your `devbox.json`:
+
+```json
+"include": [
+  "github:cultureamp/devbox-extras?dir=plugins/ca-changesets"
+]
+```
+
+All usage should follow the [changesets documentation](https://changesets-docs.vercel.app/) with the exception of the `yarn` command, which is not required, and instead you can call `changeset` directly.

--- a/plugins/ca-changesets/README.md
+++ b/plugins/ca-changesets/README.md
@@ -10,4 +10,4 @@ To include changesets in your project, add the following to the top level of you
 ]
 ```
 
-All usage should follow the [changesets documentation](https://changesets-docs.vercel.app/) with the exception of the `yarn` command, which is not required, and instead you can call `changeset` directly.
+All usage should follow the [changesets documentation](https://changesets-docs.vercel.app/) with the exception of usage of the `yarn` command, which is not required and instead you can call the `changeset` binary directly.

--- a/plugins/ca-changesets/bin/ca-changeset-wrapper
+++ b/plugins/ca-changesets/bin/ca-changeset-wrapper
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ ! -d "$DEVBOX_WD/.changesets" ]; then
+    pnpm dlx @changesets/cli init
+    # TODO: ensure package.json exists with version
+    cat $DEVBOX_WD/package.json | jq '.version' | semver
+fi
+
+pnpm dlx @changesets/cli "$@"

--- a/plugins/ca-changesets/bin/ca-changeset-wrapper
+++ b/plugins/ca-changesets/bin/ca-changeset-wrapper
@@ -1,11 +1,4 @@
 #!/usr/bin/env bash
 
 set -e
-
-if [ ! -d "$DEVBOX_WD/.changesets" ]; then
-    pnpm dlx @changesets/cli init
-    # TODO: ensure package.json exists with version
-    cat $DEVBOX_WD/package.json | jq '.version' | semver
-fi
-
 pnpm dlx @changesets/cli "$@"

--- a/plugins/ca-changesets/bin/ca-changeset-wrapper
+++ b/plugins/ca-changesets/bin/ca-changeset-wrapper
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 set -e
-pnpm dlx @changesets/cli "$@"
+npx --yes @changesets/cli "$@"

--- a/plugins/ca-changesets/plugin.json
+++ b/plugins/ca-changesets/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "ca-changesets",
+  "version": "0.0.1",
+  "description": "Culture Amp plugin for the npm package @changesets/cli",
+  "readme": "README.md",
+  // TODO: will this clobber the project's node version?
+  "packages": ["nodejs", "jq", "semver-tool"],
+  "create_files": {
+    "{{.Virtenv}}/bin/ca-changeset": "bin/ca-changeset-wrapper"
+  },
+  "env": {
+    "DEVBOX_COREPACK_ENABLED": "true",
+    "PATH": "{{ .Virtenv }}/bin:$PATH"
+  }
+}

--- a/plugins/ca-changesets/plugin.json
+++ b/plugins/ca-changesets/plugin.json
@@ -1,9 +1,8 @@
 {
   "name": "ca-changesets",
   "version": "0.0.1",
-  "description": "Culture Amp plugin for the npm package @changesets/cli",
+  "description": "Culture Amp plugin providing the binary included in the npm package @changesets/cli",
   "readme": "README.md",
-  // TODO: will this clobber the project's node version?
   "packages": ["nodejs"],
   "create_files": {
     "{{.Virtenv}}/bin/changeset": "bin/ca-changeset-wrapper"

--- a/plugins/ca-changesets/plugin.json
+++ b/plugins/ca-changesets/plugin.json
@@ -8,6 +8,6 @@
     "{{.Virtenv}}/bin/changeset": "bin/ca-changeset-wrapper"
   },
   "env": {
-    "PATH": "{{ .Virtenv }}/bin:$PATH"
+    "PATH": "{{ .Virtenv }}/bin/:$PATH"
   }
 }

--- a/plugins/ca-changesets/plugin.json
+++ b/plugins/ca-changesets/plugin.json
@@ -4,9 +4,9 @@
   "description": "Culture Amp plugin for the npm package @changesets/cli",
   "readme": "README.md",
   // TODO: will this clobber the project's node version?
-  "packages": ["nodejs", "jq", "semver-tool"],
+  "packages": ["nodejs"],
   "create_files": {
-    "{{.Virtenv}}/bin/ca-changeset": "bin/ca-changeset-wrapper"
+    "{{.Virtenv}}/bin/changeset": "bin/ca-changeset-wrapper"
   },
   "env": {
     "DEVBOX_COREPACK_ENABLED": "true",

--- a/plugins/ca-changesets/plugin.json
+++ b/plugins/ca-changesets/plugin.json
@@ -8,7 +8,6 @@
     "{{.Virtenv}}/bin/changeset": "bin/ca-changeset-wrapper"
   },
   "env": {
-    "DEVBOX_COREPACK_ENABLED": "true",
     "PATH": "{{ .Virtenv }}/bin:$PATH"
   }
 }

--- a/plugins/ca-changesets/plugin.json
+++ b/plugins/ca-changesets/plugin.json
@@ -7,7 +7,7 @@
   "create_files": {
     "{{.Virtenv}}/bin/changeset": "bin/ca-changeset-wrapper"
   },
-  "env": {
-    "PATH": "{{ .Virtenv }}/bin/:$PATH"
+  "shell": {
+    "init_hook": ["PATH={{ .Virtenv }}/bin:$PATH"]
   }
 }


### PR DESCRIPTION
A thin wrapper to @changesets/cli, using the `npx` command to call `changeset`. 
This will install `changeset` if it does not already exist, without requirement of a `package.json` file, and without creating a `node_modules/` directory.

I have ensured that:
- This plugin will install nodejs, however the consuming devbox project's node version will not be clobbered, as the project's environment is loaded after the plugin environment.
