### PR TITLE
feat: allow external postgres to be used by debezium plugin

### DIFF
--- a/plugins/debezium-server/config/process-compose.yaml
+++ b/plugins/debezium-server/config/process-compose.yaml
@@ -26,7 +26,7 @@ processes:
       period_seconds: 5
       failure_threshold: 1000
       exec:
-        command: pg_isready -U postgres
+        command: pg_isready -h ${DB_HOSTNAME} -U postgres -p ${DB_PORT}
 
   postgres_invariant_checks:
     command: devbox run postgres-version-check

--- a/plugins/debezium-server/plugin.json
+++ b/plugins/debezium-server/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "debezium-server",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Plugin for running Debezium Server locally",
   "packages": [
     "nodejs@22.4.1",


### PR DESCRIPTION
This PR changes the readiness command to allow the Debezium server plugin to use a postgres outside of the devbox virtual environment.