### PR TITLE
stop calling hotel w/ sudo

### DIFF
--- a/scripts/install_hotel.sh
+++ b/scripts/install_hotel.sh
@@ -90,7 +90,7 @@ install_hotel() {
 		echo "github.token: $github_token" >> ~/.config/hotel/config.yaml
 	fi
 	log "=> installing hotel, this will ask for a sudo password"
-	sudo "$hotel_bin_path/hotel" setup launcher
+	"$hotel_bin_path/hotel" setup launcher
 }
 
 main() {


### PR DESCRIPTION
This call to hotel with sudo is breaking the install flow.

Hotel will now die if called as root. This change was made due to issues around hotel writing files as root.
The previously required sudo call is now made by hotel, to stop these issues.
