### PR TITLE
Install script prints error when latest release not found

### DIFF
--- a/scripts/install_hotel.sh
+++ b/scripts/install_hotel.sh
@@ -56,6 +56,8 @@ download_latest_hotel() {
 		grep '"url": ".*/releases/assets/.*"' |
 		cut -d\" -f4)
 
+	latest_release_found=0
+
 	for url in $release_asset_urls; do
 		# the only way to get a release's file name is to download it and write-out the filename
 		downloaded_file=$(
@@ -67,11 +69,19 @@ download_latest_hotel() {
 		)
 		if [ "$downloaded_file" = "$hotel_tarball_name" ]; then
 			tar -xzf "$downloaded_file"
+			latest_release_found=1
 			return
 		else
 			rm "$downloaded_file"
 		fi
 	done
+	if [ "$latest_release_found" = "0" ]; then
+        log ""
+        logRed "the installer has failed to download the latest version of hotel"
+        logRed "please see this page for instructions to manually install hotel: https://cultureamp.atlassian.net/wiki/spaces/DE/pages/4741201953/Manually+installing+hotel"
+        log ""
+        exit 1
+    fi
 }
 
 install_hotel() {


### PR DESCRIPTION
# Summary

Recently we had an issue in the install script where no downloaded Github release filename matched the hotel release we expected. There was no error messaging to declare this problem. To fix this I have introduced a print statement for this case which links out to documentation on how to manually install `hotel`.

Context: https://cultureamp.slack.com/archives/C05D8BD1CB1/p1738902067155539