### PR TITLE
corepack plugin that sets integrity keys

### DIFF
--- a/plugins/corepack/plugin.json
+++ b/plugins/corepack/plugin.json
@@ -1,15 +1,20 @@
 {
   "name": "corepack",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "readme": "README.md",
   "env": {
     "PATH": "{{ .Virtenv }}/corepack-bin/:$PATH"
   },
+  "packages": ["nodePackages.semver@7.6.3"],
   "shell": {
     "init_hook": [
-      "echo WARNING: corepack plugin is built into devbox since v0.10 and can be removed from devbox.json and replaced with the env var DEVBOX_COREPACK_ENABLED=1",
       "mkdir -p {{ .Virtenv }}/corepack-bin",
-      "corepack enable --install-directory \"{{ .Virtenv }}/corepack-bin/\""
+      "corepack enable --install-directory \"{{ .Virtenv }}/corepack-bin/\"",
+      "",
+      "corepack_version=$(corepack --version)",
+      "if semver --range \"<0.31\" \"$corepack_version\" >/dev/null; then",
+      "   export COREPACK_INTEGRITY_KEYS='{\"npm\":[{\"expires\":\"2025-01-29T00:00:00.000Z\",\"keyid\":\"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA\",\"keytype\":\"ecdsa-sha2-nistp256\",\"scheme\":\"ecdsa-sha2-nistp256\",\"key\":\"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg==\"},{\"expires\":null,\"keyid\":\"SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U\",\"keytype\":\"ecdsa-sha2-nistp256\",\"scheme\":\"ecdsa-sha2-nistp256\",\"key\":\"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEY6Ya7W++7aUPzvMTrezH6Ycx3c+HOKYCcNGybJZSCJq/fd7Qa8uuAKtdIkUQtQiEKERhAmE5lMMJhP8OkDOa2g==\"}]}'",
+      "fi"
     ]
   }
 }


### PR DESCRIPTION
# repro
```sh
# init a temp dir with devbox, node and a package.json
cd $(mktemp -d)
devbox init
devbox add jq nodejs@20
npm init -y

# enable corepack in the devbox project
devbox run -- jq '.env.DEVBOX_COREPACK_ENABLED = "1"' devbox.json > tmp.json && mv tmp.json devbox.json

# tell corepack to use pnpm (expected to fail)
devbox run -- corepack cache clean # otherwise it will only fail once
devbox run -- corepack use pnpm
```

# manual fix
Because corepack is bundled with nodejs, unless you can upgrade to a version of node that comes with corepack@0.31.0 (I don’t know which those are) you’re stuck with that error. AFAIK the only other fix is to set the COREPACK_INTEGRITY_KEYS env var. It can be 0 to ignore checks but that’s not a path I want to follow. You can set it to the values that corepack@0.31.0 comes with like this and it will work
```sh 
export COREPACK_INTEGRITY_KEYS='{"npm":[{"expires":"2025-01-29T00:00:00.000Z","keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="},{"expires":null,"keyid":"SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEY6Ya7W++7aUPzvMTrezH6Ycx3c+HOKYCcNGybJZSCJq/fd7Qa8uuAKtdIkUQtQiEKERhAmE5lMMJhP8OkDOa2g=="}]}'

# try again (expected to succeed)
devbox run -- corepack use pnpm
```

*this PR implements the above manual fix as a plugin* I've tested it in a local repo and it seems to work but I haven't tried to enumerate and test edge cases yet.