### PR TITLE
Bump debezium to 3.0.0.Final

### DIFF
--- a/packages/debezium-server.nix
+++ b/packages/debezium-server.nix
@@ -8,7 +8,7 @@
 }:
 let
   pname = "debezium-server";
-  version = "2.7.1.Final";
+  version = "3.0.0.Final";
   tarballName = "debezium-server-dist-${version}.tar.gz";
 in
 stdenv.mkDerivation {
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   src = fetchzip {
     url = "https://repo1.maven.org/maven2/io/debezium/debezium-server-dist/${version}/${tarballName}";
-    hash = "sha256-y7elU/9zBjGSpBFwAXHvhZvLb0QvvBazwDNP9yBQdJw=";
+    hash = "sha256-RiMBvg9925qcBL04XQ6mKfRg/OznvliSYGjo+HOFzJc=";
   };
 
   installPhase = ''

--- a/packages/debezium-server.nix
+++ b/packages/debezium-server.nix
@@ -3,7 +3,7 @@
 
 { stdenv
 , fetchzip
-, jdk
+, jdk21
 ,
 }:
 let
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
 
     source $out/jmx/enable_jmx.sh
 
-    exec "${jdk}/bin/java" \
+    exec "${jdk21}/bin/java" \
       $DEBEZIUM_OPTS $JAVA_OPTS \
       -cp \$RUNNER:"\''${CONNECTOR_CONF_PATH:-conf}":"\$LIB_PATH" io.debezium.server.Main "\$@"
     EOF

--- a/plugins/debezium-server/config/debezium-server/application.properties
+++ b/plugins/debezium-server/config/debezium-server/application.properties
@@ -42,8 +42,8 @@ debezium.transforms.heartbeat1.replacement=${FARM}.${INTERNAL_TOPIC_PREFIX}.debe
 debezium.transforms.heartbeat2.type=org.apache.kafka.connect.transforms.RegexRouter
 debezium.transforms.heartbeat2.regex=${FARM}.${INTERNAL_TOPIC_PREFIX}.${DB_SCHEMA}.${HEARTBEAT_TABLE}(.*?)
 debezium.transforms.heartbeat2.replacement=_${FARM}.${INTERNAL_TOPIC_PREFIX}.debezium-heartbeat-table
-debezium.source.database.initial.statements=INSERT INTO ${DB_SCHEMA}.${HEARTBEAT_TABLE} (id, ts) VALUES (1, NOW()) ON CONFLICT(id) DO UPDATE SET ts=EXCLUDED.ts;
-debezium.source.heartbeat.action.query=INSERT INTO ${DB_SCHEMA}.${HEARTBEAT_TABLE} (id, ts) VALUES (1, NOW()) ON CONFLICT(id) DO UPDATE SET ts=EXCLUDED.ts;
+debezium.source.database.initial.statements=INSERT INTO ${DB_SCHEMA}.${HEARTBEAT_TABLE} (id, heartbeat_recorded) VALUES (1, NOW()) ON CONFLICT(id) DO UPDATE SET heartbeat_recorded=EXCLUDED.heartbeat_recorded;
+debezium.source.heartbeat.action.query=INSERT INTO ${DB_SCHEMA}.${HEARTBEAT_TABLE} (id, heartbeat_recorded) VALUES (1, NOW()) ON CONFLICT(id) DO UPDATE SET heartbeat_recorded=EXCLUDED.heartbeat_recorded;
 debezium.source.heartbeat.interval.ms=10000
 debezium.source.database.hostname=${DB_HOSTNAME}
 debezium.source.database.port=${DB_PORT}

--- a/plugins/debezium-server/config/debezium-server/init_outbox.sql
+++ b/plugins/debezium-server/config/debezium-server/init_outbox.sql
@@ -65,22 +65,12 @@ DECLARE
     schema_name text := current_setting('vars.schema_name');
     heartbeat_table_name text := current_setting('vars.heartbeat_table_name');
 BEGIN
-    -- Create the sequence if it doesn't exist
-    EXECUTE FORMAT('
-    CREATE SEQUENCE IF NOT EXISTS %s.%s_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;', schema_name, heartbeat_table_name);
-
     -- Create table if it does not exist
     EXECUTE FORMAT('
     CREATE TABLE IF NOT EXISTS %s.%s (
-    id bigint NOT NULL DEFAULT nextval(''%s.%s_id_seq''::regclass),
-    ts timestamp without time zone NOT NULL,
-    CONSTRAINT %s_id_key UNIQUE (id)
-    );', schema_name, heartbeat_table_name, schema_name, heartbeat_table_name, heartbeat_table_name);
+    id SERIAL PRIMARY KEY,
+    heartbeat_recorded TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );', schema_name, heartbeat_table_name);
 
     EXECUTE FORMAT('ALTER TABLE %s.%s OWNER TO dbz_replication_role;', schema_name, heartbeat_table_name);
 END $$;

--- a/plugins/debezium-server/plugin.json
+++ b/plugins/debezium-server/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "debezium-server",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Plugin for running Debezium Server locally",
   "packages": [
     "nodejs@22.4.1",


### PR DESCRIPTION
# Context

The current stable version of Debezium Server listed [here](https://debezium.io/releases/) is `3.0`, and we are currently on `2.7`.

This includes an update to the Nix flake and required configuration changes so Debezium server `3.0.0.Final` can be used locally