### PR TITLE
adds process-compose schema

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -13,6 +13,9 @@
       "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#bats.libraries.bats-support",
       "source": "nixpkg"
     },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "resolved": "github:NixOS/nixpkgs/bd3bac8bfb542dbde7ffffb6987a1a1f9d41699f?lastModified=1743014863&narHash=sha256-jAIUqsiN2r3hCuHji80U7NNEafpIMBXiwKlSrjWMlpg%3D"
+    },
     "nixpkgs-fmt": {
       "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#nixpkgs-fmt",
       "source": "nixpkg"

--- a/process-compose/README.md
+++ b/process-compose/README.md
@@ -1,0 +1,9 @@
+This schema allows for validation and autocompletion of the `process-compose.yaml` file that devbox uses.
+
+To make use of this file you can include the schema in your file by adding the following line to the top of your `process-compose.yaml` file:
+
+```yaml
+# yaml-language-server: $schema: https://raw.githubusercontent.com/cultureamp/devbox-extras/main/process-compose/schema.yaml
+```
+
+This requires the yaml-language-server to be installed. You can install an extension for VSCode that provides this functionality [here](https://marketplace.visualstudio.com/items/?itemName=redhat.vscode-yaml)

--- a/process-compose/README.md
+++ b/process-compose/README.md
@@ -1,4 +1,6 @@
-This schema allows for validation and autocompletion of the `process-compose.yaml` file that devbox uses.
+# What is this?
+
+This schema allows for validation of the `process-compose.yaml` file that devbox uses. It also provides autocompletion for the file in your editor.
 
 To make use of this file you can include the schema in your file by adding the following line to the top of your `process-compose.yaml` file:
 
@@ -6,4 +8,34 @@ To make use of this file you can include the schema in your file by adding the f
 # yaml-language-server: $schema: https://raw.githubusercontent.com/cultureamp/devbox-extras/main/process-compose/schema.yaml
 ```
 
-This requires the yaml-language-server to be installed. You can install an extension for VSCode that provides this functionality [here](https://marketplace.visualstudio.com/items/?itemName=redhat.vscode-yaml)
+This requires the yaml-language-server to be installed. You can install this LSP for VSCode [here](https://marketplace.visualstudio.com/items/?itemName=redhat.vscode-yaml)
+
+## Detect process-compose.yaml files
+
+You can configure the yaml-language-server to use this schema for all `process-compose.yaml` files by following the below.
+
+### VSCode
+
+By adding the following to your settings.json file:
+
+```json
+"yaml.schemas": {
+  "https://raw.githubusercontent.com/cultureamp/devbox-extras/main/process-compose/schema.yaml": "/process-compose.yaml"
+}
+```
+
+### Other editors
+
+If you are using another editor, you can achieve this by adding the following to your language server settings:
+
+```json
+"yaml-language-server": {
+  "settings": {
+    "yaml": {
+      "schemas": {
+        "https://raw.githubusercontent.com/cultureamp/devbox-extras/main/process-compose/schema.yaml": "/process-compose.yaml"
+      }
+    }
+  }
+}
+```

--- a/process-compose/schema.yaml
+++ b/process-compose/schema.yaml
@@ -1,3 +1,6 @@
+# this schema was created following the process-compose documentation at: https://f1bonacc1.github.io/process-compose/
+# and the json schema documentation can be found at: https://json-schema.org/understanding-json-schema/reference
+
 title: Process Compose Schema
 type: object
 additionalProperties: false

--- a/process-compose/schema.yaml
+++ b/process-compose/schema.yaml
@@ -9,7 +9,7 @@ properties:
 
   is_strict:
     type: boolean
-    description: "Enable strict configuration validation to catch typos and errors"
+    description: "Enable strict configuration validation to catch typos and errors (default: false)"
 
   shell:
     type: object
@@ -18,7 +18,7 @@ properties:
     properties:
       shell_command:
         type: string
-        description: "The shell command to use (e.g., bash, python3)"
+        description: "The shell command to use (e.g., bash, python3) (default: bash on Linux/macOS, cmd on Windows)"
       shell_argument:
         type: string
         description: "The shell argument to use (e.g., -c, -m)"
@@ -36,7 +36,7 @@ properties:
 
   log_location:
     type: string
-    description: "Path to the unified log file"
+    description: "Path to the unified log file (default: none)"
 
   log_length:
     type: integer
@@ -66,35 +66,35 @@ properties:
             description: "Determines if the rotated log files should be compressed"
       fields_order:
         type: array
-        description: "Order of logging fields"
+        description: 'Order of logging fields (default: ["time", "level", "message"])'
         items:
           type: string
       disable_json:
         type: boolean
-        description: "Output as plain text"
+        description: "Output as plain text (default: false)"
       timestamp_format:
         type: string
-        description: "Timestamp format"
+        description: "Timestamp format (default: HH:MM AM/PM for plain text, 2006-01-02T15:04:05Z07:00 for JSON)"
       no_metadata:
         type: boolean
-        description: "Don't log process name and replica number"
+        description: "Don't log process name and replica number (default: false)"
       add_timestamp:
         type: boolean
-        description: "Add timestamp to the logger"
+        description: "Add timestamp to the logger (default: false)"
       no_color:
         type: boolean
-        description: "Disable ANSI colors in the logger"
+        description: "Disable ANSI colors in the logger (default: false)"
       flush_each_line:
         type: boolean
-        description: "Disable buffering and flush each line to the log file"
+        description: "Disable buffering and flush each line to the log file (default: false)"
 
   is_tui_disabled:
     type: boolean
-    description: "Disable the Terminal User Interface"
+    description: "Disable the Terminal User Interface (default: false)"
 
   disable_env_expansion:
     type: boolean
-    description: "Globally disable automatic environment variable expansion"
+    description: "Globally disable automatic environment variable expansion (default: false)"
 
   vars:
     type: object
@@ -143,31 +143,31 @@ definitions:
         additionalProperties: true
       is_daemon:
         type: boolean
-        description: "Flag for background/detached processes"
+        description: "Flag for background/detached processes (default: false)"
       is_foreground:
         type: boolean
-        description: "Flag for foreground processes requiring full tty access"
+        description: "Flag for foreground processes requiring full tty access (default: false)"
       is_tty:
         type: boolean
-        description: "Simulate a TTY for a process"
+        description: "Simulate a TTY for a process (default: false)"
       is_elevated:
         type: boolean
-        description: "Run process with elevated privileges (sudo/runas)"
+        description: "Run process with elevated privileges (sudo/runas) (default: false)"
       disabled:
         type: boolean
-        description: "Disable process execution"
+        description: "Disable process execution (default: false)"
       disable_ansi_colors:
         type: boolean
-        description: "Disable ANSI colors in the process logs"
+        description: "Disable ANSI colors in the process logs (default: false)"
       replicas:
         type: integer
-        description: "Number of replicas to run"
+        description: "Number of replicas to run (default: 1)"
       launch_timeout_seconds:
         type: integer
-        description: "Time to wait for background processes to launch"
+        description: "Time to wait for background processes to launch (default: 5)"
       log_location:
         type: string
-        description: "Path to the process log file"
+        description: "Path to the process log file (default: none)"
       ready_log_line:
         type: string
         description: "Log line to wait for when using process_log_ready condition"
@@ -175,7 +175,7 @@ definitions:
         $ref: "#/properties/log_configuration"
       namespace:
         type: string
-        description: "Namespace for the process"
+        description: "Namespace for the process (default: default)"
       depends_on:
         type: object
         description: "Process dependencies"
@@ -193,6 +193,7 @@ definitions:
                   "process_started",
                   "process_log_ready",
                 ]
+              description: "Condition for dependency"
       availability:
         type: object
         additionalProperties: false
@@ -200,20 +201,20 @@ definitions:
         properties:
           restart:
             type: string
-            description: "Process restart policy"
+            description: "Process restart policy (default: no)"
             enum: ["no", "always", "on_failure", "exit_on_failure"]
           backoff_seconds:
             type: integer
-            description: "Time to wait between restarts"
+            description: "Time to wait between restarts (default: 1)"
           max_restarts:
             type: integer
-            description: "Maximum number of restarts (0 = unlimited)"
+            description: "Maximum number of restarts, 0 = unlimited (default: 0)"
           exit_on_end:
             type: boolean
-            description: "Terminate Process Compose once this process ends"
+            description: "Terminate Process Compose once this process ends (default: false)"
           exit_on_skipped:
             type: boolean
-            description: "Terminate Process Compose once this process is skipped"
+            description: "Terminate Process Compose once this process is skipped (default: false)"
       shutdown:
         type: object
         additionalProperties: false
@@ -224,13 +225,13 @@ definitions:
             description: "Command to execute for graceful shutdown"
           timeout_seconds:
             type: integer
-            description: "Timeout for graceful shutdown before sending SIGKILL"
+            description: "Timeout for graceful shutdown before sending SIGKILL (default: 10)"
           signal:
             type: integer
-            description: "Signal number to send to the process (1-31)"
+            description: "Signal number to send to the process, 1-31 (default: 15 if shutdown.command is not defined)"
           parent_only:
             type: boolean
-            description: "Only signal the parent process instead of the whole process group"
+            description: "Only signal the parent process instead of the whole process group (default: no)"
       readiness_probe:
         $ref: "#/definitions/probe"
       liveness_probe:
@@ -251,7 +252,7 @@ definitions:
             description: "Command to execute"
           working_dir:
             type: string
-            description: "Working directory for the command"
+            description: "Working directory for the command (default: process working directory)"
       http_get:
         type: object
         additionalProperties: false
@@ -262,29 +263,29 @@ definitions:
             description: "Host name to connect to"
           scheme:
             type: string
-            description: "Scheme to use (HTTP or HTTPS)"
+            description: "Scheme to use (HTTP or HTTPS) (default: HTTP)"
             enum: ["http", "https"]
           path:
             type: string
-            description: "Path to access on the HTTP server"
+            description: "Path to access on the HTTP server (default: /)"
           port:
             type: [integer, string]
             description: "Port to access the process"
       initial_delay_seconds:
         type: integer
-        description: "Seconds after the process has started before probes are initiated"
+        description: "Seconds after the process has started before probes are initiated (default: 0)"
       period_seconds:
         type: integer
-        description: "How often to perform the probe in seconds"
+        description: "How often to perform the probe in seconds (default: 10)"
       timeout_seconds:
         type: integer
-        description: "Number of seconds after which the probe times out"
+        description: "Number of seconds after which the probe times out (default: 1)"
       success_threshold:
         type: integer
-        description: "Minimum consecutive successes for the probe to be considered successful"
+        description: "Minimum consecutive successes for the probe to be considered successful (default: 1)"
       failure_threshold:
         type: integer
-        description: "When a probe fails, retry this many times before giving up"
+        description: "When a probe fails, retry this many times before giving up (default: 3)"
     oneOf:
       - required: ["exec"]
       - required: ["http_get"]

--- a/process-compose/schema.yaml
+++ b/process-compose/schema.yaml
@@ -1,5 +1,7 @@
 title: Process Compose Schema
 type: object
+additionalProperties: false
+
 properties:
   version:
     type: string
@@ -11,6 +13,7 @@ properties:
 
   shell:
     type: object
+    additionalProperties: false
     description: "Shell configuration for executing commands"
     properties:
       shell_command:
@@ -41,10 +44,12 @@ properties:
 
   log_configuration:
     type: object
+    additionalProperties: false
     description: "Logger configuration"
     properties:
       rotation:
         type: object
+        additionalProperties: false
         description: "Log rotation settings"
         properties:
           max_size_mb:
@@ -115,6 +120,7 @@ properties:
 definitions:
   process:
     type: object
+    additionalProperties: false
     description: "Process definition"
     properties:
       command:
@@ -175,6 +181,7 @@ definitions:
         description: "Process dependencies"
         additionalProperties:
           type: object
+          additionalProperties: false
           properties:
             condition:
               type: string
@@ -188,6 +195,7 @@ definitions:
                 ]
       availability:
         type: object
+        additionalProperties: false
         description: "Process restart policy"
         properties:
           restart:
@@ -208,6 +216,7 @@ definitions:
             description: "Terminate Process Compose once this process is skipped"
       shutdown:
         type: object
+        additionalProperties: false
         description: "Process termination configuration"
         properties:
           command:
@@ -229,10 +238,12 @@ definitions:
 
   probe:
     type: object
+    additionalProperties: false
     description: "Health probe configuration"
     properties:
       exec:
         type: object
+        additionalProperties: false
         description: "Execute a command to check health"
         properties:
           command:
@@ -243,6 +254,7 @@ definitions:
             description: "Working directory for the command"
       http_get:
         type: object
+        additionalProperties: false
         description: "Make an HTTP request to check health"
         properties:
           host:

--- a/process-compose/schema.yaml
+++ b/process-compose/schema.yaml
@@ -1,0 +1,278 @@
+title: Process Compose Schema
+type: object
+properties:
+  version:
+    type: string
+    description: "Version of the process-compose schema"
+
+  is_strict:
+    type: boolean
+    description: "Enable strict configuration validation to catch typos and errors"
+
+  shell:
+    type: object
+    description: "Shell configuration for executing commands"
+    properties:
+      shell_command:
+        type: string
+        description: "The shell command to use (e.g., bash, python3)"
+      shell_argument:
+        type: string
+        description: "The shell argument to use (e.g., -c, -m)"
+
+  environment:
+    type: array
+    description: "Global environment variables in KEY=VALUE format"
+    items:
+      type: string
+
+  log_level:
+    type: string
+    description: "Process compose console log level"
+    enum: ["trace", "debug", "info", "warn", "error", "fatal", "panic"]
+
+  log_location:
+    type: string
+    description: "Path to the unified log file"
+
+  log_length:
+    type: integer
+    description: "UI log buffer size (default: 1000)"
+
+  log_configuration:
+    type: object
+    description: "Logger configuration"
+    properties:
+      rotation:
+        type: object
+        description: "Log rotation settings"
+        properties:
+          max_size_mb:
+            type: integer
+            description: "The max size in MB of the logfile before it's rolled"
+          max_age_days:
+            type: integer
+            description: "The max age in days to keep a logfile"
+          max_backups:
+            type: integer
+            description: "The max number of rolled files to keep"
+          compress:
+            type: boolean
+            description: "Determines if the rotated log files should be compressed"
+      fields_order:
+        type: array
+        description: "Order of logging fields"
+        items:
+          type: string
+      disable_json:
+        type: boolean
+        description: "Output as plain text"
+      timestamp_format:
+        type: string
+        description: "Timestamp format"
+      no_metadata:
+        type: boolean
+        description: "Don't log process name and replica number"
+      add_timestamp:
+        type: boolean
+        description: "Add timestamp to the logger"
+      no_color:
+        type: boolean
+        description: "Disable ANSI colors in the logger"
+      flush_each_line:
+        type: boolean
+        description: "Disable buffering and flush each line to the log file"
+
+  is_tui_disabled:
+    type: boolean
+    description: "Disable the Terminal User Interface"
+
+  disable_env_expansion:
+    type: boolean
+    description: "Globally disable automatic environment variable expansion"
+
+  vars:
+    type: object
+    description: "Global variables for template rendering"
+    additionalProperties: true
+
+  env_cmds:
+    type: object
+    description: "Commands to execute to populate environment variables"
+    additionalProperties:
+      type: string
+
+  extends:
+    type: string
+    description: "Path to another process-compose file to extend"
+
+  processes:
+    type: object
+    description: "Definition of processes to run"
+    additionalProperties:
+      $ref: "#/definitions/process"
+
+definitions:
+  process:
+    type: object
+    description: "Process definition"
+    properties:
+      command:
+        type: string
+        description: "The command to execute"
+      working_dir:
+        type: string
+        description: "The working directory for the command"
+      description:
+        type: string
+        description: "Process description shown in the Process Info Dialog"
+      environment:
+        type: array
+        description: "Process-specific environment variables in KEY=VALUE format"
+        items:
+          type: string
+      vars:
+        type: object
+        description: "Process-specific variables for template rendering"
+        additionalProperties: true
+      is_daemon:
+        type: boolean
+        description: "Flag for background/detached processes"
+      is_foreground:
+        type: boolean
+        description: "Flag for foreground processes requiring full tty access"
+      is_tty:
+        type: boolean
+        description: "Simulate a TTY for a process"
+      is_elevated:
+        type: boolean
+        description: "Run process with elevated privileges (sudo/runas)"
+      disabled:
+        type: boolean
+        description: "Disable process execution"
+      disable_ansi_colors:
+        type: boolean
+        description: "Disable ANSI colors in the process logs"
+      replicas:
+        type: integer
+        description: "Number of replicas to run"
+      launch_timeout_seconds:
+        type: integer
+        description: "Time to wait for background processes to launch"
+      log_location:
+        type: string
+        description: "Path to the process log file"
+      ready_log_line:
+        type: string
+        description: "Log line to wait for when using process_log_ready condition"
+      log_configuration:
+        $ref: "#/properties/log_configuration"
+      namespace:
+        type: string
+        description: "Namespace for the process"
+      depends_on:
+        type: object
+        description: "Process dependencies"
+        additionalProperties:
+          type: object
+          properties:
+            condition:
+              type: string
+              enum:
+                [
+                  "process_completed",
+                  "process_completed_successfully",
+                  "process_healthy",
+                  "process_started",
+                  "process_log_ready",
+                ]
+      availability:
+        type: object
+        description: "Process restart policy"
+        properties:
+          restart:
+            type: string
+            description: "Process restart policy"
+            enum: ["no", "always", "on_failure", "exit_on_failure"]
+          backoff_seconds:
+            type: integer
+            description: "Time to wait between restarts"
+          max_restarts:
+            type: integer
+            description: "Maximum number of restarts (0 = unlimited)"
+          exit_on_end:
+            type: boolean
+            description: "Terminate Process Compose once this process ends"
+          exit_on_skipped:
+            type: boolean
+            description: "Terminate Process Compose once this process is skipped"
+      shutdown:
+        type: object
+        description: "Process termination configuration"
+        properties:
+          command:
+            type: string
+            description: "Command to execute for graceful shutdown"
+          timeout_seconds:
+            type: integer
+            description: "Timeout for graceful shutdown before sending SIGKILL"
+          signal:
+            type: integer
+            description: "Signal number to send to the process (1-31)"
+          parent_only:
+            type: boolean
+            description: "Only signal the parent process instead of the whole process group"
+      readiness_probe:
+        $ref: "#/definitions/probe"
+      liveness_probe:
+        $ref: "#/definitions/probe"
+
+  probe:
+    type: object
+    description: "Health probe configuration"
+    properties:
+      exec:
+        type: object
+        description: "Execute a command to check health"
+        properties:
+          command:
+            type: string
+            description: "Command to execute"
+          working_dir:
+            type: string
+            description: "Working directory for the command"
+      http_get:
+        type: object
+        description: "Make an HTTP request to check health"
+        properties:
+          host:
+            type: string
+            description: "Host name to connect to"
+          scheme:
+            type: string
+            description: "Scheme to use (HTTP or HTTPS)"
+            enum: ["http", "https"]
+          path:
+            type: string
+            description: "Path to access on the HTTP server"
+          port:
+            type: [integer, string]
+            description: "Port to access the process"
+      initial_delay_seconds:
+        type: integer
+        description: "Seconds after the process has started before probes are initiated"
+      period_seconds:
+        type: integer
+        description: "How often to perform the probe in seconds"
+      timeout_seconds:
+        type: integer
+        description: "Number of seconds after which the probe times out"
+      success_threshold:
+        type: integer
+        description: "Minimum consecutive successes for the probe to be considered successful"
+      failure_threshold:
+        type: integer
+        description: "When a probe fails, retry this many times before giving up"
+    oneOf:
+      - required: ["exec"]
+      - required: ["http_get"]


### PR DESCRIPTION
# Summary

To avoid errors, and provide autocompletion functionality I have produced a schema for `process-compose.yaml` files. This PR includes this schema, as well as some documentation on how to make use of the schema.

## Changes

This PR also bumps the devbox lockfile to include the changes introduced in devbox v0.14.0.


## Verifying

You can use this schema prior to it being merged to main by using the url "https://raw.githubusercontent.com/cultureamp/devbox-extras/tfm/process-compose-schema/process-compose/schema.yaml" like the below.
```yaml
# yaml-language-server: $schema: https://raw.githubusercontent.com/cultureamp/devbox-extras/tfm/process-compose-schema/process-compose/schema.yaml
```


