### PR TITLE
fix schema registry in kafkactl config

### DIFF
--- a/plugins/ca-kafka-local/config/kafkactl/config.yaml
+++ b/plugins/ca-kafka-local/config/kafkactl/config.yaml
@@ -13,7 +13,7 @@ contexts:
       password: ${KAFKA_SASL_PASSWORD}
       mechanism: scram-sha512
 
-    avro:
-      schemaRegistry: ${SCHEMA_REGISTRY_URL}
+    schemaRegistry:
+      url: ${SCHEMA_REGISTRY_URL}
 
 current-context: local

--- a/plugins/ca-kafka-local/plugin.json
+++ b/plugins/ca-kafka-local/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-kafka-local",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Environment variables and tools to interact with `kafka-local` in your service",
   "readme": "README.md",
   "packages": ["kafkactl@5", "kcat@1", "envsubst", "kaf"],


### PR DESCRIPTION
# Context

kafkactl config.yaml is incorrectly structured, and will not Avro encode with schema registry.

This fixes up the expected file structure so `kafkactl` can successfully produce Avro encoded messages to local Kafka