### PR TITLE
lock kafkactl version due to breaking changes

### DIFF
--- a/plugins/ca-kafka-local/plugin.json
+++ b/plugins/ca-kafka-local/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "ca-kafka-local",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Environment variables and tools to interact with `kafka-local` in your service",
   "readme": "README.md",
-  "packages": ["kafkactl@5", "kcat@1", "envsubst", "kaf"],
+  "packages": ["kafkactl@5.7.0", "kcat@1", "envsubst", "kaf"],
   "env": {
     "PATH": "{{ .Virtenv }}/bin:$PATH",
     "KAFKA_BROKERS": "localhost:14231",


### PR DESCRIPTION
# Context

The kafka local plugin includes `kafkactl@5`, however different repositories using this plugin are installing different versions -- and the versioning does not seem to respect semantic versioning.

For example, from v5.5.1 to v5.6.0: https://github.com/deviceinsight/kafkactl/releases/tag/v5.6.0

A PR is introduced [here](https://github.com/deviceinsight/kafkactl/pull/240) that changes the configuration file structure, which is a breaking change.

We should lock kafkactl to a specific version to avoid any unexpected breaking changes