### PR TITLE
fix multi-gitter package that wasn't building on newer nix versions

### DIFF
--- a/packages/multi-gitter.nix
+++ b/packages/multi-gitter.nix
@@ -25,6 +25,7 @@ if system == "x86_64-darwin" then
     src = fetchzip {
       url = "https://github.com/lindell/multi-gitter/releases/download/v${version}/multi-gitter_${version}_Darwin_x86_64.tar.gz";
       hash = "sha256-k+vngTWJZ/ySiDWPVWBZdoGnaKyUMffY2au6WGYClLQ=";
+      stripRoot = false;
     };
   }
 
@@ -36,6 +37,7 @@ else if system == "aarch64-darwin" then
     src = fetchzip {
       url = "https://github.com/lindell/multi-gitter/releases/download/v${version}/multi-gitter_${version}_Darwin_ARM64.tar.gz";
       hash = "sha256-DkqcQrz0PLjb21skaks6BrdLyxEymhmkdH8vFNrGJqQ=";
+      stripRoot = false;
     };
   }
 


### PR DESCRIPTION
adds `stripRoot=false` as suggested by build failure