### PR TITLE
update multi-gitter to latest

### DIFF
--- a/packages/multi-gitter.nix
+++ b/packages/multi-gitter.nix
@@ -1,8 +1,11 @@
+# get updated hashs with:
+# `nix-hash --to-sri --type sha256 $(nix-prefetch-url --unpack https://github.com/lindell/multi-gitter/releases/download/v${version}/multi-gitter_${version}_Darwin_${arch}.tar.gz)`
+
 { system, lib, stdenv, fetchzip }:
 let
   inherit (lib) licenses;
   pname = "multi-gitter-${version}";
-  version = "0.52.0";
+  version = "0.57.1";
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin
@@ -24,7 +27,7 @@ if system == "x86_64-darwin" then
 
     src = fetchzip {
       url = "https://github.com/lindell/multi-gitter/releases/download/v${version}/multi-gitter_${version}_Darwin_x86_64.tar.gz";
-      hash = "sha256-k+vngTWJZ/ySiDWPVWBZdoGnaKyUMffY2au6WGYClLQ=";
+      hash = "sha256-O9jt6HatnuivMx8Lcdc5Qd5Y4nM9ke7ktQQYy3PadRA=";
       stripRoot = false;
     };
   }
@@ -36,7 +39,7 @@ else if system == "aarch64-darwin" then
 
     src = fetchzip {
       url = "https://github.com/lindell/multi-gitter/releases/download/v${version}/multi-gitter_${version}_Darwin_ARM64.tar.gz";
-      hash = "sha256-DkqcQrz0PLjb21skaks6BrdLyxEymhmkdH8vFNrGJqQ=";
+      hash = "sha256-o6GxO8voV1qpXm+RHNv/WKmA+sVSbpUVINtk2WptsZY=";
       stripRoot = false;
     };
   }


### PR DESCRIPTION
went down a bit of a rabbit hole getting the hashes the proper way
- previously I'd been using and recommending the "fake hash method", but found that to be clumsy for multiple cpu archs and have run into obscure netskope issues
  - see: https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-fetchers-updating-source-hashes-fakehash-method
- figuring out the correct chaining of `nix-hash` and `nix-prefetch-*` was something I've been trying to do for a while, this seems pretty solid