### PR TITLE
adds nixpkgs unstable to devbox lockfile

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -13,6 +13,10 @@
       "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#bats.libraries.bats-support",
       "source": "nixpkg"
     },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2025-07-25T08:26:56Z",
+      "resolved": "github:NixOS/nixpkgs/6027c30c8e9810896b92429f0092f624f7b1aace?lastModified=1753432016&narHash=sha256-cnL5WWn%2FxkZoyH%2F03NNUS7QgW5vI7D1i74g48qplCvg%3D"
+    },
     "nixpkgs-fmt": {
       "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#nixpkgs-fmt",
       "source": "nixpkg"


### PR DESCRIPTION
I'm unsure why this change is only just occuring now, looks like we've kept the lockfile up to date and I'm not getting the same diff in `hotel`
