### PR TITLE
adds ca-ruler plugin

### DIFF
--- a/plugins/ca-ruler/README.md
+++ b/plugins/ca-ruler/README.md
@@ -1,0 +1,13 @@
+ca-ruler is a devbox plugin that acts as a thin wrapper around the npm package [ruler](https://github.com/intellectronica/ruler).
+
+This is provided so that any non-JS projects can make use of the `ruler` binary without managing `node` or a `node_modules/` directory.
+
+To include ruler in your project, add the following to the top level of your `devbox.json`:
+
+```json
+"include": [
+  "github:cultureamp/devbox-extras?dir=plugins/ca-ruler"
+]
+```
+
+All usage should follow the [ruler documentation](https://github.com/intellectronica/ruler#core-concepts).

--- a/plugins/ca-ruler/bin/ca-ruler-wrapper
+++ b/plugins/ca-ruler/bin/ca-ruler-wrapper
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -e
+npx --yes @intellectronica/ruler "$@"

--- a/plugins/ca-ruler/plugin.json
+++ b/plugins/ca-ruler/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "ca-ruler",
+  "version": "0.0.1",
+  "description": "Culture Amp plugin providing the binary included in the npm package @intellectronica/ruler",
+  "packages": ["nodejs"],
+  "create_files": {
+    "{{.Virtenv}}/bin/ruler": "bin/ca-ruler-wrapper"
+  },
+  "shell": {
+    "init_hook": ["PATH={{ .Virtenv }}/bin:$PATH"]
+  }
+}


### PR DESCRIPTION
# Summary

A few projects are now making use of the npm package `@intellectronica/ruler`, this plugin is intended to make it easier to use for projects that don't depend on node.

## Direction

We've chosen to roll this out as a devbox plugin as it will allow us to change the implementation. Potential reasons for changing the implementation include: 
- Managing hooks
- Delivering enterprise wide policies for all agents, although we could achieve this with `hotel`.

## Potential improvements

Being a devbox plugin also grants us the ability to write files (such as initialising ruler config, or extending rule files) as well as run scripts (such as managing the ruler initialisation). 

 ## Manual verification

To verify the work in this PR you can add the following to the `devbox.json` of some project in the same folder as devbox-extras.

```
  "include": [
    "path:../devbox-extras/plugins/ca-ruler"
  ],
```
