### PR TITLE
Rename debezium readme process

### DIFF
--- a/plugins/debezium-server/config/process-compose.yaml
+++ b/plugins/debezium-server/config/process-compose.yaml
@@ -1,7 +1,7 @@
 version: "0.5"
 
 processes:
-  readme:
+  README_DEBEZIUM:
     command: "devbox run debezium-server-readme; tail -f /dev/null"
     availability:
       restart: always

--- a/plugins/debezium-server/plugin.json
+++ b/plugins/debezium-server/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "debezium-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Plugin for running Debezium Server locally",
   "packages": [
     "nodejs@22.4.1",


### PR DESCRIPTION
This is so that is appears in a projects as `README_DEBEZIUM` instead of
`readme` which can conflict with a projects readme process.
