### PR TITLE
Update checkout to v6 and devbox-install-action to v14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,8 @@ jobs:
   check-linting-and-formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: jetify-com/devbox-install-action@v0.9.0
+      - uses: actions/checkout@v6
+      - uses: jetify-com/devbox-install-action@v0.14.0
       - run: devbox run lint
   hotel-install-script:
     strategy:
@@ -17,7 +17,7 @@ jobs:
         runs-on: [macos-13, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: run install script
         shell: bash
         run: |
@@ -28,7 +28,7 @@ jobs:
   ensure-combined-cert-up-to-date:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
       - run: |
           nix run .#generate-netskope-combined-cert


### PR DESCRIPTION
Fixes:
```
Fetching binary from
https://install.determinate.systems/nix/nix-installer-x86_64-linux?ci=github&correlation=GH-633cf9f2-0ddf-4140-b042-cc4b5f2387ea
  Invalid URL
```
