### PR TITLE
Remove deprecated macos runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # See: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         # for the mapping of architecture to the runner type.
-        runs-on: [macos-13, macos-latest, ubuntu-latest]
+        runs-on: [macos-14, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

Fixes:
```
The configuration 'macos-13-us-default' is not supported
```
