### PR TITLE
Fix issue checking for status too soon

### DIFF
--- a/plugins/ca-common/bin/run-with-services-up
+++ b/plugins/ca-common/bin/run-with-services-up
@@ -101,6 +101,12 @@ main() {
   while true; do
     statuses=$(curl -s "http://localhost:$PCPORT/processes" | list_process_statuses)
 
+    # If statuses is empty, the API isn't ready yet — keep waiting.
+    if [[ -z "$statuses" ]]; then
+      echo "Waiting for process-compose API to return process data..."
+      continue
+    fi
+
     # Print an update.
     devbox services ls
     echo ""
@@ -110,7 +116,7 @@ main() {
 
     # Proceed if all processes are ready.
     echo "$statuses" | grep -q "Waiting" || break
-
+    
     # Check if timeout exceeded
     local elapsed=$(($(date +%s) - start_time))
     (( elapsed >= timeout_seconds )) && { echo "Timeout waiting for services to start after ${timeout_seconds}s"; exit 1; }


### PR DESCRIPTION
Fixes an issue where we try to check the status API too soon and things are still starting up where the status is empty. This fix waits until it's not empty before proceeding.

Verified in this PR:
https://github.com/cultureamp/bef-rails-pg-demo/actions/runs/24436249274/job/71391008674

Example of a build where we checking an empty status, not finding the Waiting string there, and then proceeding too early leading to failure: https://github.com/cultureamp/bef-rails-pg-demo/actions/runs/24431957606/job/71378116195
