### PR TITLE
Add failed process logs

### DIFF
--- a/plugins/ca-common/bin/run-with-services-up
+++ b/plugins/ca-common/bin/run-with-services-up
@@ -99,7 +99,9 @@ main() {
   local start_time
   start_time=$(date +%s)
   while true; do
-    statuses=$(curl -s "http://localhost:$PCPORT/processes" | list_process_statuses)
+    local processes_response
+    processes_response=$(curl -s "http://localhost:$PCPORT/processes")
+    statuses=$(echo "$processes_response" | list_process_statuses)
 
     # If statuses is empty, the API isn't ready yet — keep waiting.
     if [[ -z "$statuses" ]]; then
@@ -112,7 +114,14 @@ main() {
     echo ""
 
     # Exit if any process has an error.
-    echo "$statuses" | grep -q "Error" && { echo -e "Error: A process failed.\n"; exit 1; }
+    if echo "$statuses" | grep -q "Error"; then
+      echo "Error: One or more processes failed."
+      echo ""
+      local failed_processes
+      mapfile -t failed_processes < <(echo "$processes_response" | list_failed_processes)
+      print_failed_process_logs "$PCPORT" "${failed_processes[@]}"
+      exit 1
+    fi
 
     # Proceed if all processes are ready.
     echo "$statuses" | grep -q "Waiting" || break
@@ -149,6 +158,32 @@ main() {
   fi
   echo ""
 
+}
+
+list_failed_processes() {
+  jq -r '
+    [.data[] |
+      select(
+        .status != "Restarting" and
+        .status != "Disabled" and
+        .status != "Skipped" and
+        .exit_code != 0
+      ) | .name
+    ] | .[]
+  '
+}
+
+print_failed_process_logs() {
+  local pcport="$1"
+  shift
+  local failed_processes=("$@")
+
+  for process_name in "${failed_processes[@]}"; do
+    echo "::group::Logs for failed process: $process_name"
+    curl -s "http://localhost:$pcport/process/logs/$process_name/0/0" | jq -r '.logs[]'
+    echo "::endgroup::"
+    echo ""
+  done
 }
 
 list_process_statuses() {

--- a/plugins/ca-common/bin/run-with-services-up
+++ b/plugins/ca-common/bin/run-with-services-up
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-# Return codes for wait_for_services
 readonly WAIT_PROCESS_ERROR=1
 readonly WAIT_TIMEOUT=2
 
@@ -96,17 +95,16 @@ main() {
   #  Error: process-compose is not running or it's config is missing. To start it, run `devbox services up`
   #  source: failed to find projectDir /var/folders/cp/kp1z7bk902qd09vnskdwr11r0000gp/T/tmp.cJGGFVeVuP in config.Instances
   #PCPORT=$(devbox services pcport) || { echo "Failed to get process-compose port"; exit 1; }
-
   echo ""
 
-  # Wait for key services to start.
   wait_for_process_compose_api
 
-  echo "::group::Waiting for processes to start"
+  echo "::group::Waiting for services to start"
   wait_for_services
   local wait_result=$?
   echo "::endgroup::"
 
+  # Handle failure if any process failed or if we timed out.
   if [ $wait_result -ne 0 ]; then
     handle_wait_failure "$wait_result"
     exit 1
@@ -120,10 +118,7 @@ main() {
     exit 1
   fi
 
-  echo ""
-  echo "Running command: $*"
-  echo ""
-
+  echo "::group::Running command: $*"
   # Handle both quoted and unquoted command arguments.
   # If there's only one argument, try to execute it as a shell command.
   # Otherwise, execute all arguments directly.
@@ -135,7 +130,7 @@ main() {
     # Multiple arguments - execute directly
     "${@}" || { echo "Command failed: $*"; exit 1; }
   fi
-  echo ""
+  echo "::endgroup::"
 
 }
 
@@ -207,32 +202,6 @@ handle_wait_failure() {
   fi
 }
 
-list_failed_processes() {
-  jq -r '
-    [.data[] |
-      select(
-        .status != "Restarting" and
-        .status != "Disabled" and
-        .status != "Skipped" and
-        .exit_code != 0
-      ) | .name
-    ] | .[]
-  '
-}
-
-list_not_ready_processes() {
-  jq -r '
-    [.data[] |
-      select(
-        (.status != "Completed" or .exit_code != 0) and
-        .status != "Disabled" and
-        .status != "Skipped" and
-        (.has_ready_probe != true or .is_ready != "Ready")
-      ) | .name
-    ] | .[]
-  '
-}
-
 print_process_logs() {
   local pcport="$1"
   local header_prefix="$2"
@@ -274,5 +243,32 @@ list_process_statuses() {
     ] | add
   '
 }
+
+list_failed_processes() {
+  jq -r '
+    [.data[] |
+      select(
+        .status != "Restarting" and
+        .status != "Disabled" and
+        .status != "Skipped" and
+        .exit_code != 0
+      ) | .name
+    ] | .[]
+  '
+}
+
+list_not_ready_processes() {
+  jq -r '
+    [.data[] |
+      select(
+        (.status != "Completed" or .exit_code != 0) and
+        .status != "Disabled" and
+        .status != "Skipped" and
+        (.has_ready_probe != true or .is_ready != "Ready")
+      ) | .name
+    ] | .[]
+  '
+}
+
 
 main "${@}"

--- a/plugins/ca-common/bin/run-with-services-up
+++ b/plugins/ca-common/bin/run-with-services-up
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Return codes for wait_for_services
+readonly WAIT_PROCESS_ERROR=1
+readonly WAIT_TIMEOUT=2
+
 usage() {
   cat << EOF
 Usage: $0 [--timeout=SECONDS] [--service=SERVICE_NAME] [--process-compose-file=PATH] [--help] <command> [args...]
@@ -96,42 +100,17 @@ main() {
   echo ""
 
   # Wait for key services to start.
-  local start_time
-  start_time=$(date +%s)
-  while true; do
-    local processes_response
-    processes_response=$(curl -s "http://localhost:$PCPORT/processes")
-    statuses=$(echo "$processes_response" | list_process_statuses)
+  wait_for_process_compose_api
 
-    # If statuses is empty, the API isn't ready yet — keep waiting.
-    if [[ -z "$statuses" ]]; then
-      echo "Waiting for process-compose API to return process data..."
-      continue
-    fi
+  echo "::group::Waiting for processes to start"
+  wait_for_services
+  local wait_result=$?
+  echo "::endgroup::"
 
-    # Print an update.
-    devbox services ls
-    echo ""
-
-    # Exit if any process has an error.
-    if echo "$statuses" | grep -q "Error"; then
-      echo "Error: One or more processes failed."
-      echo ""
-      local failed_processes
-      mapfile -t failed_processes < <(echo "$processes_response" | list_failed_processes)
-      print_failed_process_logs "$PCPORT" "${failed_processes[@]}"
-      exit 1
-    fi
-
-    # Proceed if all processes are ready.
-    echo "$statuses" | grep -q "Waiting" || break
-    
-    # Check if timeout exceeded
-    local elapsed=$(($(date +%s) - start_time))
-    (( elapsed >= timeout_seconds )) && { echo "Timeout waiting for services to start after ${timeout_seconds}s"; exit 1; }
-
-    sleep 3
-  done
+  if [ $wait_result -ne 0 ]; then
+    handle_wait_failure "$wait_result"
+    exit 1
+  fi
 
   # Check if process-compose is still running before executing the command.
   # Wait a moment for process-compose to shut down if all processes have finished.
@@ -160,6 +139,74 @@ main() {
 
 }
 
+wait_for_process_compose_api() {
+  while true; do
+    local statuses
+    statuses=$(curl -s "http://localhost:$PCPORT/processes" | list_process_statuses)
+    if [[ -n "$statuses" ]]; then
+      return
+    fi
+    echo "Waiting for process-compose API to return process data..."
+    sleep 3
+  done
+}
+
+wait_for_services() {
+  local start_time
+  start_time=$(date +%s)
+
+  while true; do
+    local processes_response
+    processes_response=$(curl -s "http://localhost:$PCPORT/processes")
+    local statuses
+    statuses=$(echo "$processes_response" | list_process_statuses)
+
+    devbox services ls
+    echo ""
+
+    # Fail if any process has an error.
+    if echo "$statuses" | grep -q "Error"; then
+      return $WAIT_PROCESS_ERROR
+    fi
+
+    # Timeout exceeded.
+    local elapsed=$(($(date +%s) - start_time))
+    if (( elapsed >= timeout_seconds )); then
+      return $WAIT_TIMEOUT
+    fi
+
+    # Succeed if no processes are still waiting.
+    if ! echo "$statuses" | grep -q "Waiting"; then
+      return 0
+    fi
+
+    sleep 3
+  done
+}
+
+handle_wait_failure() {
+  local wait_result="$1"
+  local processes_response
+  processes_response=$(curl -s "http://localhost:$PCPORT/processes")
+
+  if [ "$wait_result" -eq $WAIT_PROCESS_ERROR ]; then
+    echo ""
+    echo "Error: One or more processes failed."
+    echo ""
+    local failed_processes
+    mapfile -t failed_processes < <(echo "$processes_response" | list_failed_processes)
+    print_process_logs "$PCPORT" "Logs for failed process" "${failed_processes[@]}"
+  elif [ "$wait_result" -eq $WAIT_TIMEOUT ]; then
+    echo "Timeout waiting for services to start after ${timeout_seconds}s"
+    echo ""
+    local not_ready_processes
+    mapfile -t not_ready_processes < <(echo "$processes_response" | list_not_ready_processes)
+    if [ ${#not_ready_processes[@]} -gt 0 ]; then
+      print_process_logs "$PCPORT" "Logs for process" "${not_ready_processes[@]}"
+    fi
+  fi
+}
+
 list_failed_processes() {
   jq -r '
     [.data[] |
@@ -173,14 +220,32 @@ list_failed_processes() {
   '
 }
 
-print_failed_process_logs() {
-  local pcport="$1"
-  shift
-  local failed_processes=("$@")
+list_not_ready_processes() {
+  jq -r '
+    [.data[] |
+      select(
+        (.status != "Completed" or .exit_code != 0) and
+        .status != "Disabled" and
+        .status != "Skipped" and
+        (.has_ready_probe != true or .is_ready != "Ready")
+      ) | .name
+    ] | .[]
+  '
+}
 
-  for process_name in "${failed_processes[@]}"; do
-    echo "::group::Logs for failed process: $process_name"
-    curl -s "http://localhost:$pcport/process/logs/$process_name/0/0" | jq -r '.logs[]'
+print_process_logs() {
+  local pcport="$1"
+  local header_prefix="$2"
+  shift 2
+  local process_names=("$@")
+
+  for process_name in "${process_names[@]}"; do
+    echo "::group::${header_prefix}: $process_name"
+    local logs_response
+    logs_response=$(curl -s "http://localhost:$pcport/process/logs/$process_name/0/0")
+    if ! echo "$logs_response" | jq -r '.logs[]' 2>/dev/null; then
+      echo "(Could not retrieve logs for this process)"
+    fi
     echo "::endgroup::"
     echo ""
   done

--- a/plugins/ca-common/tests/run-with-services-up/failed-process-logs/process-compose.yaml
+++ b/plugins/ca-common/tests/run-with-services-up/failed-process-logs/process-compose.yaml
@@ -1,0 +1,14 @@
+version: "0.5"
+
+processes:
+  README:
+    command: "devbox run readme; tail -f /dev/null"
+
+  process_that_fails:
+    command: echo "this is a failure log message" && exit 1
+
+  healthy_process:
+    command: sleep 2 && python3 -m http.server 5055
+    readiness_probe:
+      exec:
+        command: curl -f http://localhost:5055

--- a/plugins/ca-common/tests/run-with-services-up/failed-process-logs/test.bats
+++ b/plugins/ca-common/tests/run-with-services-up/failed-process-logs/test.bats
@@ -6,7 +6,7 @@ setup() {
 	common_setup
 }
 
-@test "a process fails to start" {
+@test "failed process logs are output with github actions group headers" {
 	run \
 		run-with-services-up \
 		--process-compose-file="$PCFILE" \
@@ -14,5 +14,6 @@ setup() {
 
 	[ $status -eq 1 ]
 	[[ "$output" == *"Error: One or more processes failed."* ]]
-	[[ "$output" != *"Command completed"* ]]
+	[[ "$output" == *"this is a failure log message"* ]]
+
 }

--- a/plugins/ca-common/tests/run-with-services-up/process-becomes-healthy-then-fails/test.bats
+++ b/plugins/ca-common/tests/run-with-services-up/process-becomes-healthy-then-fails/test.bats
@@ -13,6 +13,6 @@ setup() {
 		echo "Command completed"
 
 	[ $status -eq 1 ]
-	[[ "$output" == *"Error: A process failed."* ]]
+	[[ "$output" == *"Error: One or more processes failed."* ]]
 	[[ "$output" != *"Command completed"* ]]
 }


### PR DESCRIPTION
This PR add logging to failed processes making it easier for engineers to debug when process-compose fails to start up. It uses github action log groups to make it easier to navigate the multiple logs. Only logs for processes that fail to start are logged which should make it easier for engineers to debug causes for build failures rather than needing to check each process for issues.

Additionally this PR includes some refactoring and some extra tests.

Example of a failed process here:
https://github.com/cultureamp/bef-rails-pg-demo/actions/runs/24492406552/job/71579881775

## Alternatives considered.

We could output the logs of all the processes which would simplify the code. 