### PR TITLE
Add the dynamodb_local package to the list of packages installed by the plugin

### DIFF
--- a/plugins/dynamodb_local/README.md
+++ b/plugins/dynamodb_local/README.md
@@ -4,12 +4,10 @@ Plugin [DynamoDB local](https://docs.aws.amazon.com/amazondynamodb/latest/develo
 
 ## Use and activation
 
-1. Add the `dynamodb_local` package from this repo to your `devbox.json`
-2. Add this plugin to the `include` section of your `devbox.json`
+Add this plugin to the `include` section of your `devbox.json`
 
 ```json
 {
-  "packages": ["github:cultureamp/devbox-extras#dynamodb_local"],
   "include": ["github:cultureamp/devbox-extras?dir=plugins/dynamodb_local"]
 }
 ```

--- a/plugins/dynamodb_local/plugin.json
+++ b/plugins/dynamodb_local/plugin.json
@@ -2,6 +2,9 @@
   "name": "dynamodb_local",
   "version": "1.0.0",
   "readme": "Plugin for dynamodb_local",
+  "packages": [
+    "github:cultureamp/devbox-extras#dynamodb_local"
+  ],
   "env": {
     "DYNAMODB_DATA_PATH": "{{ .Virtenv }}/data",
     "DYNAMODB_PORT": "8000"


### PR DESCRIPTION
This is so that we don't need to explicitly install the package when
using the plugin like we do
here:
https://github.com/cultureamp/frontend-ops/blob/416e333112fcfd06cf4915ed5f201f48b8466220/devbox.json#L5-L8
