### PR TITLE
Make ca-ensure-requirements default to the full devbox services up set

### DIFF
--- a/plugins/ca-common/README.md
+++ b/plugins/ca-common/README.md
@@ -14,5 +14,9 @@ Sets sensible defaults for cultureamp devbox repos and provides some common help
   - Usage: run-with-services-up [--timeout=SECONDS] [--service=SERVICE_NAME] [--process-compose-file=PATH] [--help] <command> [args...]
 
 - Adds ca-ensure-requirements command
-  - Ensures a named process (or meta-process) and its full dependency graph is satisfied — daemons Ready (via readiness_probe), one-shots Completed with exit 0. Autodetects mode: if the graph contains a long-running daemon, process-compose is left running; otherwise it is reaped after the graph completes.
-  - Usage: ca-ensure-requirements [--timeout=SECONDS] [--process-compose-file=PATH] [--help] <name>
+  - Runs the equivalent of `devbox services up`, waits for every process to be ready or completed, and logs errors on failure — daemons Ready (via readiness_probe), one-shots Completed with exit 0. With `--process=NAME` it instead ensures only the named process (or meta-process) and its full dependency graph. Autodetects mode: if the graph contains a long-running daemon, process-compose is left running; otherwise it is reaped after the graph completes.
+  - Usage: ca-ensure-requirements [--process=NAME] [--timeout=SECONDS] [--process-compose-file=PATH] [--help]
+  - Notes:
+    - A long-running process must declare a readiness_probe — without one it cannot be verified and the run times out.
+    - Processes marked `disabled: true` are skipped, matching `devbox services up`. If process-compose is already running from a targeted boot (e.g. `devbox services up some-name`), the default mode ensures only the processes that instance has enabled.
+    - Breaking change: the process name used to be a positional argument (`ca-ensure-requirements <name>`); it is now `--process=<name>`, and running with no flag ensures everything.

--- a/plugins/ca-common/bin/_lib.bash
+++ b/plugins/ca-common/bin/_lib.bash
@@ -100,6 +100,26 @@ wait_for_port() {
   return 1
 }
 
+# Emit the name of every enabled process in the running process-compose
+# instance, one per line. The API reports the full merged configuration
+# (root file + plugin-contributed files), so on an instance booted with no
+# target this is exactly the set a bare `devbox services up` starts.
+# Processes with status "Disabled" are excluded: that status covers both
+# config `disabled: true` (which devbox doesn't run either) and processes
+# excluded by a targeted boot — PC serialises the two identically, so a
+# target-scoped instance keeps its scope. Returns 1 (no output) if the API
+# is unreachable or returns non-JSON. Requires $PCPORT.
+list_enabled_process_names() {
+  local processes_response
+  # $PCPORT is a caller-set global (see file-header docstring), not a typo of `pcport`.
+  # shellcheck disable=SC2153
+  processes_response=$(curl -s --connect-timeout 2 "http://localhost:$PCPORT/processes") || return 1
+  if [ -z "$processes_response" ] || ! echo "$processes_response" | jq -e . >/dev/null 2>&1; then
+    return 1
+  fi
+  echo "$processes_response" | jq -r '.data[] | select(.status != "Disabled") | .name'
+}
+
 # Map a depends_on condition onto the runtime requirement it places on the
 # dependency. /process/info serialises conditions as the ProcessCondition
 # integer enum (0=process_completed, 1=process_completed_successfully,

--- a/plugins/ca-common/bin/ca-ensure-requirements
+++ b/plugins/ca-common/bin/ca-ensure-requirements
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
 
-# Ensures a named process (or meta-process) and its full dependency graph
-# is satisfied. Autodetects mode from the runtime state after the graph
-# is satisfied:
+# Runs the equivalent of `devbox services up`, waits for every process to
+# be ready or completed, and logs errors on failure. With --process=NAME it
+# instead ensures only the named process (or meta-process) and its full
+# dependency graph.
+#
+# In both modes the process set is resolved through process-compose itself
+# (devbox merges plugin-contributed process-compose files at boot). On a
+# cold start the default mode boots PC with no target, so it covers exactly
+# what a bare `devbox services up` starts — every process not marked
+# `disabled: true`. On a warm start it ensures every process the running
+# instance has *enabled*: PC reports processes excluded by a targeted boot
+# (`devbox services up <name>`) as Disabled, indistinguishable from config
+# `disabled: true`, so a target-scoped instance keeps its scope.
+#
+# Autodetects lifecycle from the runtime state after the graph is
+# satisfied:
 #   - Any node still is_running == true → daemon-mode: PC is left running.
 #   - Every node has already Completed  → command-mode: PC is reaped.
 #
@@ -50,14 +63,17 @@ source "$SCRIPT_DIR/_lib.bash"
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [--timeout=SECONDS] [--process-compose-file=PATH] [--help] <name>
+Usage: $(basename "$0") [--process=NAME] [--timeout=SECONDS] [--process-compose-file=PATH] [--help]
 
-Ensures the named process (or meta-process) and its dependency graph are
-satisfied — daemons are Ready (via readiness_probe), one-shots are Completed
-with exit 0.
+Runs the equivalent of \`devbox services up\`, waits for every process to be
+ready or completed, and logs errors on failure. Daemons must become Ready
+(via readiness_probe), one-shots must Complete with exit 0 — a long-running
+process without a readiness_probe cannot be verified and times out.
 process-compose is left running iff the graph contains a long-running daemon.
 
 Options:
+  --process=NAME              Ensure only the named process (or meta-process)
+                              and its dependency graph, instead of every process
   --timeout=SECONDS           Timeout for the dependency graph (default: $DEFAULT_TIMEOUT)
   --process-compose-file=PATH Path to process-compose file
                               (default: \$DEVBOX_PROJECT_ROOT/process-compose.yaml, falling back to .yml)
@@ -68,8 +84,16 @@ EOF
 main() {
   local timeout_seconds=$DEFAULT_TIMEOUT
   local pcfile=""
+  local target=""
   while [[ $# -gt 0 ]]; do
     case $1 in
+      --process=*)
+        target="${1#*=}"
+        if [ -z "$target" ]; then
+          echo "Error: --process requires a non-empty process name." >&2
+          exit 1
+        fi
+        shift ;;
       --timeout=*)
         local value="${1#*=}"
         if ! [[ "$value" =~ ^[0-9]+$ ]] || [ "$value" -le 0 ]; then
@@ -103,13 +127,11 @@ main() {
     fi
   fi
 
-  if [ "$#" -ne 1 ]; then
-    echo "Error: exactly one process name is required." >&2
+  if [ "$#" -ne 0 ]; then
+    echo "Error: positional process names are no longer accepted. Use --process=$1 instead." >&2
     usage >&2
     exit 1
   fi
-
-  local target="$1"
 
   PCPORT=$(pcport_if_running)
   if [ -z "$PCPORT" ]; then
@@ -139,8 +161,12 @@ cold_start() {
   echo "process-compose is not running — booting via \`devbox services up --background\`."
   # --keep-project keeps PC alive if the dependency graph turns out to be
   # pure one-shots (which would drain PC's process list). We always tear
-  # PC down again after unless the graph has a real daemon.
-  devbox_services_up_background --pcflags=--keep-project --process-compose-file="$pcfile" "$target" \
+  # PC down again after unless the graph has a real daemon. All-mode boots
+  # with no target, so devbox starts everything — same as a bare
+  # `devbox services up`.
+  local up_args=(--pcflags=--keep-project --process-compose-file="$pcfile")
+  [ -n "$target" ] && up_args+=("$target")
+  devbox_services_up_background "${up_args[@]}" \
     || { echo "Failed to start process-compose." >&2; exit 1; }
 
   PCPORT=$(wait_for_port)
@@ -152,7 +178,7 @@ cold_start() {
   echo "process-compose booted on port $PCPORT."
   echo ""
 
-  run_dependency_graph "$target" "$timeout_seconds"
+  run_target_or_all "$target" "$timeout_seconds"
 }
 
 warm_start() {
@@ -161,7 +187,38 @@ warm_start() {
   echo "process-compose already running on port $PCPORT — using API."
   echo ""
 
-  run_dependency_graph "$target" "$timeout_seconds"
+  run_target_or_all "$target" "$timeout_seconds"
+}
+
+# Resolve the run's graph roots — the named process in --process mode, or
+# every enabled process otherwise — and hand off to the shared flow. The
+# all-mode root set comes from the process-compose API, which reports the
+# full merged configuration (root file + plugin-contributed files).
+# Disabled processes are excluded, as `devbox services up` doesn't run
+# them; note PC also reports processes excluded by a targeted boot as
+# Disabled (see the file-header docstring for the scope rule this
+# implies). Requires $PCPORT.
+run_target_or_all() {
+  local target="$1"
+  local timeout_seconds="$2"
+
+  if [ -n "$target" ]; then
+    run_dependency_graph "$timeout_seconds" "'$target' and dependencies" "$target"
+    return
+  fi
+
+  local names
+  names=$(list_enabled_process_names) \
+    || { echo "Failed to enumerate processes from the process-compose API." >&2; exit 1; }
+  local roots=() name
+  while IFS= read -r name; do
+    [ -n "$name" ] && roots+=("$name")
+  done <<< "$names"
+  if [ "${#roots[@]}" -eq 0 ]; then
+    echo "Error: no enabled processes found in the process-compose configuration." >&2
+    exit 1
+  fi
+  run_dependency_graph "$timeout_seconds" "All processes" "${roots[@]}"
 }
 
 # Echo "yes" if any dependency graph member is currently a running service
@@ -195,13 +252,17 @@ graph_has_long_running_process() {
 # and either clear the trap (daemon-mode: leave PC up) or let it fire
 # (command-mode: reap PC).
 run_dependency_graph() {
-  local target="$1"
-  local timeout_seconds="$2"
+  local timeout_seconds="$1"
+  # Human-readable subject for the final status messages, e.g.
+  # "'foo' and dependencies" or "All processes".
+  local label="$2"
+  shift 2
+  # Remaining args: the graph roots.
 
   # expand emits "name<TAB>requirement" rows in dependency order; split
   # into the name list the helpers iterate and the per-node requirement map.
   local graph_tsv
-  graph_tsv=$(expand_dependency_graph "$target") \
+  graph_tsv=$(expand_dependency_graph "$@") \
     || { echo "Failed to expand dependency graph." >&2; exit 1; }
 
   local dependency_graph
@@ -234,9 +295,9 @@ run_dependency_graph() {
   has_daemon=$(graph_has_long_running_process "$dependency_graph" "$wait_snapshot")
   if [ "$has_daemon" = "yes" ]; then
     disarm_reaper
-    echo "'$target' and dependencies are ready. Leaving process-compose running."
+    echo "$label are ready. Leaving process-compose running."
   else
-    echo "'$target' and dependencies completed successfully."
+    echo "$label completed successfully."
   fi
 }
 

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-mixed-graph/process-compose.yaml
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-mixed-graph/process-compose.yaml
@@ -1,0 +1,64 @@
+version: "0.5"
+
+# A realistic app boot graph for all-mode: one-shots, daemons with
+# readiness probes, a meta-process, and a disabled process. Unlike the
+# target-mode mixed-graph fixture, every enabled process here — including
+# ones outside the for-verify meta's dependency graph — must be started
+# and satisfied when the command runs with no --process.
+processes:
+  install-dependencies:
+    command: |
+      MARKER_DIR="${MARKER_DIR:-./.tmp}"
+      mkdir -p "$MARKER_DIR"
+      touch "$MARKER_DIR/install_dependencies.ran"
+
+  database-server:
+    command: python3 -m http.server 6190
+    readiness_probe:
+      exec:
+        command: curl -f http://localhost:6190
+
+  database-migrations:
+    command: |
+      MARKER_DIR="${MARKER_DIR:-./.tmp}"
+      mkdir -p "$MARKER_DIR"
+      touch "$MARKER_DIR/database_migrations.ran"
+    depends_on:
+      install-dependencies:
+        condition: process_completed_successfully
+      database-server:
+        condition: process_healthy
+
+  # Outside the for-verify graph — target mode would never start this, but
+  # all-mode must.
+  web-server:
+    command: python3 -m http.server 5155
+    readiness_probe:
+      exec:
+        command: curl -f http://localhost:5155
+    depends_on:
+      install-dependencies:
+        condition: process_completed_successfully
+
+  # Also outside the for-verify graph.
+  background-worker:
+    command: python3 -m http.server 6170
+    readiness_probe:
+      exec:
+        command: curl -f http://localhost:6170
+    depends_on:
+      database-migrations:
+        condition: process_completed_successfully
+
+  disabled-process:
+    command: |
+      MARKER_DIR="${MARKER_DIR:-./.tmp}"
+      mkdir -p "$MARKER_DIR"
+      touch "$MARKER_DIR/disabled_process.ran"
+      exit 1
+    disabled: true
+
+  for-verify:
+    depends_on:
+      database-migrations:
+        condition: process_completed_successfully

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-mixed-graph/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-mixed-graph/test.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+load "../../../test_helper"
+
+setup() {
+	common_setup
+}
+
+teardown() {
+	common_teardown
+}
+
+@test "all-mode satisfies every enabled process and leaves process-compose running" {
+	setup_nothing_running
+
+	run ca-ensure-requirements --process-compose-file="$PCFILE"
+
+	assert_succeeded
+	[[ "$output" == *"All processes are ready"* ]]
+	[ -f "$MARKER_DIR/install_dependencies.ran" ]
+	[ -f "$MARKER_DIR/database_migrations.ran" ]
+
+	# All daemons started — including ones outside the for-verify graph,
+	# which target mode would have left alone.
+	run curl --silent --fail http://localhost:6190  # database-server
+	[ "$status" -eq 0 ]
+	run curl --silent --fail http://localhost:5155  # web-server
+	[ "$status" -eq 0 ]
+	run curl --silent --fail http://localhost:6170  # background-worker
+	[ "$status" -eq 0 ]
+
+	# The disabled process must be skipped, not started and waited on.
+	[ ! -f "$MARKER_DIR/disabled_process.ran" ]
+
+	# Daemons are running → daemon-mode → PC left up.
+	assert_pc_still_running
+}

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-one-fails/process-compose.yaml
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-one-fails/process-compose.yaml
@@ -1,0 +1,15 @@
+version: "0.5"
+
+# All-mode failure reporting: one process fails while another succeeds.
+# The run must exit non-zero and dump the failing process's logs.
+processes:
+  healthy-oneshot:
+    command: |
+      MARKER_DIR="${MARKER_DIR:-./.tmp}"
+      mkdir -p "$MARKER_DIR"
+      touch "$MARKER_DIR/healthy_oneshot.ran"
+
+  failing-oneshot:
+    command: |
+      echo "distinctive-failure-log-line"
+      exit 1

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-one-fails/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-one-fails/test.bats
@@ -10,12 +10,15 @@ teardown() {
 	common_teardown
 }
 
-@test "slow one-shot target that exits non-zero fails and reaps process-compose" {
+@test "all-mode fails and dumps logs when any process fails" {
 	setup_nothing_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=slow-failing-oneshot
+	run ca-ensure-requirements --process-compose-file="$PCFILE"
 
 	assert_failed_with_dependency_graph_error
+	[[ "$output" == *"Logs for failing-oneshot"* ]]
+	[[ "$output" == *"distinctive-failure-log-line"* ]]
+
 	# Failure path: reaper trap fires.
 	assert_pc_reaped
 }

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-probeless-daemon-times-out/process-compose.yaml
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-probeless-daemon-times-out/process-compose.yaml
@@ -1,0 +1,16 @@
+version: "0.5"
+
+# Documents all-mode's strictness: a root gets the `default` requirement
+# (Ready or Completed-0), and a long-running process without a
+# readiness_probe can satisfy neither — it is indistinguishable from a
+# slow one-shot mid-run. `devbox services up` would happily run this;
+# all-mode must time out instead of reporting an unverifiable success.
+processes:
+  probeless-daemon:
+    command: python3 -m http.server 7175
+
+  quick-oneshot:
+    command: |
+      MARKER_DIR="${MARKER_DIR:-./.tmp}"
+      mkdir -p "$MARKER_DIR"
+      touch "$MARKER_DIR/quick_oneshot.ran"

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-probeless-daemon-times-out/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-probeless-daemon-times-out/test.bats
@@ -10,17 +10,15 @@ teardown() {
 	common_teardown
 }
 
-@test "fails when a dep never passes its readiness probe" {
+@test "all-mode times out on a long-running process without a readiness probe" {
 	setup_nothing_running
 
-	run \
-		ca-ensure-requirements \
-		--process-compose-file="$PCFILE" \
-		--timeout=5 \
-		--process=ready-check
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --timeout=5
 
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"Timeout: dependency graph did not become ready after 5s"* ]]
+	[[ "$output" == *"Logs for probeless-daemon"* ]]
+
 	# Timeout path: reaper trap fires.
 	assert_pc_reaped
 }

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-pure-oneshots/process-compose.yaml
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-pure-oneshots/process-compose.yaml
@@ -1,0 +1,26 @@
+version: "0.5"
+
+# All-mode over a graph of only one-shots: every process must Complete
+# with exit 0 and process-compose must then be reaped (command-mode).
+processes:
+  install-dependencies:
+    command: |
+      MARKER_DIR="${MARKER_DIR:-./.tmp}"
+      mkdir -p "$MARKER_DIR"
+      touch "$MARKER_DIR/install_dependencies.ran"
+
+  database-migrations:
+    command: |
+      MARKER_DIR="${MARKER_DIR:-./.tmp}"
+      mkdir -p "$MARKER_DIR"
+      touch "$MARKER_DIR/database_migrations.ran"
+    depends_on:
+      install-dependencies:
+        condition: process_completed_successfully
+
+  # No dependents and nothing depends on it — a root only all-mode reaches.
+  compile-assets:
+    command: |
+      MARKER_DIR="${MARKER_DIR:-./.tmp}"
+      mkdir -p "$MARKER_DIR"
+      touch "$MARKER_DIR/compile_assets.ran"

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-pure-oneshots/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-pure-oneshots/test.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+load "../../../test_helper"
+
+setup() {
+	common_setup
+}
+
+teardown() {
+	common_teardown
+}
+
+@test "all-mode with only one-shots completes them all and reaps process-compose" {
+	setup_nothing_running
+
+	run ca-ensure-requirements --process-compose-file="$PCFILE"
+
+	assert_succeeded
+	[[ "$output" == *"All processes completed successfully"* ]]
+	[ -f "$MARKER_DIR/install_dependencies.ran" ]
+	[ -f "$MARKER_DIR/database_migrations.ran" ]
+	[ -f "$MARKER_DIR/compile_assets.ran" ]
+
+	# Nothing long-running → command-mode → PC reaped.
+	assert_pc_reaped
+}

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-skips-disabled/process-compose.yaml
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-skips-disabled/process-compose.yaml
@@ -1,0 +1,20 @@
+version: "0.5"
+
+# All-mode must exclude disabled processes, matching `devbox services up`.
+# The disabled process both leaves a marker and exits non-zero, so if
+# all-mode started or waited on it the run would fail — success plus a
+# missing marker proves it was skipped entirely.
+processes:
+  some-oneshot:
+    command: |
+      MARKER_DIR="${MARKER_DIR:-./.tmp}"
+      mkdir -p "$MARKER_DIR"
+      touch "$MARKER_DIR/some_oneshot.ran"
+
+  disabled-failing-process:
+    command: |
+      MARKER_DIR="${MARKER_DIR:-./.tmp}"
+      mkdir -p "$MARKER_DIR"
+      touch "$MARKER_DIR/disabled_failing_process.ran"
+      exit 1
+    disabled: true

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-skips-disabled/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/all-processes-skips-disabled/test.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load "../../../test_helper"
+
+setup() {
+	common_setup
+}
+
+teardown() {
+	common_teardown
+}
+
+@test "all-mode skips disabled processes" {
+	setup_nothing_running
+
+	run ca-ensure-requirements --process-compose-file="$PCFILE"
+
+	assert_succeeded
+	[[ "$output" == *"All processes completed successfully"* ]]
+	[ -f "$MARKER_DIR/some_oneshot.ran" ]
+	# The disabled process never ran — its failing command would otherwise
+	# have failed the run.
+	[ ! -f "$MARKER_DIR/disabled_failing_process.ran" ]
+	assert_pc_reaped
+}

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/daemon-recovers-after-crash/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/daemon-recovers-after-crash/test.bats
@@ -13,7 +13,7 @@ teardown() {
 @test "daemon that crashes once and is policy-restarted succeeds" {
 	setup_nothing_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" for-verify
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=for-verify
 
 	assert_succeeded
 	# The first run really did crash…

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/mixed-graph-oneshot-target/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/mixed-graph-oneshot-target/test.bats
@@ -16,7 +16,7 @@ teardown() {
 @test "one-shot target with a daemon dep succeeds and process-compose is left running" {
 	setup_nothing_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" oneshot-target
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=oneshot-target
 
 	assert_succeeded
 	[ -f "$MARKER_DIR/oneshot_target.ran" ]

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/mixed-graph-succeeds/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/mixed-graph-succeeds/test.bats
@@ -13,7 +13,7 @@ teardown() {
 @test "mixed graph succeeds and process-compose is left running" {
 	setup_nothing_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" for-verify
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=for-verify
 
 	assert_succeeded
 	[ -f "$MARKER_DIR/install_dependencies.ran" ]

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/oneshot-dep-allowed-to-fail/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/oneshot-dep-allowed-to-fail/test.bats
@@ -13,7 +13,7 @@ teardown() {
 @test "dep with condition process_completed may exit non-zero without failing the run" {
 	setup_nothing_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" for-verify
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=for-verify
 
 	assert_succeeded
 	[[ "$output" == *"completed successfully"* ]]

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/oneshot-with-readiness-probe/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/oneshot-with-readiness-probe/test.bats
@@ -18,7 +18,7 @@ teardown() {
 @test "one-shot with readiness_probe is treated as command-mode and reaps process-compose" {
 	setup_nothing_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" for-verify
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=for-verify
 
 	assert_succeeded
 	[ -f "$MARKER_DIR/probe_oneshot.ran" ]

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/pure-daemon-succeeds/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/pure-daemon-succeeds/test.bats
@@ -13,7 +13,7 @@ teardown() {
 @test "pure daemon graph succeeds and process-compose is left running" {
 	setup_nothing_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" for-verify
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=for-verify
 
 	assert_succeeded
 	run curl --silent --fail http://localhost:5055

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/pure-daemon-target-fails/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/pure-daemon-target-fails/test.bats
@@ -13,7 +13,7 @@ teardown() {
 @test "daemon graph with a failing daemon fails and reaps process-compose" {
 	setup_nothing_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" for-verify
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=for-verify
 
 	assert_failed_with_dependency_graph_error
 	# Failure path: reaper trap fires regardless of graph shape.

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/pure-oneshot-succeeds/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/pure-oneshot-succeeds/test.bats
@@ -13,7 +13,7 @@ teardown() {
 @test "pure one-shot graph succeeds and process-compose is reaped" {
 	setup_nothing_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" for-verify
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=for-verify
 
 	assert_succeeded
 	[ -f "$MARKER_DIR/oneshot.ran" ]

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/pure-oneshot-target-fails/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/pure-oneshot-target-fails/test.bats
@@ -13,7 +13,7 @@ teardown() {
 @test "pure one-shot graph with a failing dep fails and reaps process-compose" {
 	setup_nothing_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" for-verify
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=for-verify
 
 	assert_failed_with_dependency_graph_error
 	assert_pc_reaped

--- a/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/slow-oneshot-target-succeeds/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/cold-boot/slow-oneshot-target-succeeds/test.bats
@@ -18,7 +18,7 @@ teardown() {
 @test "slow one-shot target succeeds only after completion and reaps process-compose" {
 	setup_nothing_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" slow-oneshot
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=slow-oneshot
 
 	assert_succeeded
 	[[ "$output" == *"completed successfully"* ]]

--- a/plugins/ca-common/tests/ca-ensure-requirements/common/command-args/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/common/command-args/test.bats
@@ -46,19 +46,27 @@ teardown() {
 	[[ "$output" == *"Invalid --timeout value"* ]]
 }
 
-# The argument-count check requires exactly one positional target. It runs
-# after the devbox-shell guard, so DEVBOX_PROJECT_ROOT must be set to reach
-# it; --process-compose-file skips the default-file lookup.
-@test "rejects invocation with no target" {
-	DEVBOX_PROJECT_ROOT="$BATS_TEST_TMPDIR" run ca-ensure-requirements --process-compose-file=/dev/null
+# Positional targets are no longer accepted (the old contract); the error
+# names the --process= replacement. The check runs after the devbox-shell
+# guard, so DEVBOX_PROJECT_ROOT must be set to reach it;
+# --process-compose-file skips the default-file lookup.
+@test "rejects a positional target with --process= guidance" {
+	DEVBOX_PROJECT_ROOT="$BATS_TEST_TMPDIR" run ca-ensure-requirements --process-compose-file=/dev/null target1
 	[ "$status" -ne 0 ]
-	[[ "$output" == *"exactly one process name is required"* ]]
+	[[ "$output" == *"positional process names are no longer accepted"* ]]
+	[[ "$output" == *"--process=target1"* ]]
 }
 
-@test "rejects invocation with multiple targets" {
+@test "rejects multiple positional targets" {
 	DEVBOX_PROJECT_ROOT="$BATS_TEST_TMPDIR" run ca-ensure-requirements --process-compose-file=/dev/null target1 target2
 	[ "$status" -ne 0 ]
-	[[ "$output" == *"exactly one process name is required"* ]]
+	[[ "$output" == *"positional process names are no longer accepted"* ]]
+}
+
+@test "rejects an empty --process= value" {
+	run ca-ensure-requirements --process=
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"--process requires a non-empty process name"* ]]
 }
 
 # When --process-compose-file is omitted, the script falls back to
@@ -74,7 +82,7 @@ processes:
     command: "true"
 YAML
 
-	DEVBOX_PROJECT_ROOT="$proj_root" run ca-ensure-requirements some-oneshot
+	DEVBOX_PROJECT_ROOT="$proj_root" run ca-ensure-requirements --process=some-oneshot
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"completed successfully"* ]]
 }
@@ -83,7 +91,7 @@ YAML
 	local proj_root="$BATS_TEST_TMPDIR/empty-proj"
 	mkdir -p "$proj_root"
 
-	DEVBOX_PROJECT_ROOT="$proj_root" run ca-ensure-requirements some-target
+	DEVBOX_PROJECT_ROOT="$proj_root" run ca-ensure-requirements --process=some-target
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"process-compose file not found"* ]]
 	[[ "$output" == *"$proj_root/process-compose.yaml"* ]]
@@ -101,7 +109,7 @@ processes:
     command: "true"
 YAML
 
-	DEVBOX_PROJECT_ROOT="$proj_root" run ca-ensure-requirements some-oneshot
+	DEVBOX_PROJECT_ROOT="$proj_root" run ca-ensure-requirements --process=some-oneshot
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"completed successfully"* ]]
 }

--- a/plugins/ca-common/tests/ca-ensure-requirements/common/nonexistent-target/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/common/nonexistent-target/test.bats
@@ -13,7 +13,7 @@ teardown() {
 @test "typo'd target exits non-zero and reaps process-compose" {
 	setup_nothing_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" no-such-target
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=no-such-target
 
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"Failed to start process-compose"* ]]

--- a/plugins/ca-common/tests/ca-ensure-requirements/common/not-in-devbox-shell/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/common/not-in-devbox-shell/test.bats
@@ -11,7 +11,7 @@ teardown() {
 }
 
 @test "exits with error when DEVBOX_PROJECT_ROOT is unset" {
-	DEVBOX_PROJECT_ROOT="" run ca-ensure-requirements some-target
+	DEVBOX_PROJECT_ROOT="" run ca-ensure-requirements --process=some-target
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"must be run inside a devbox shell"* ]]
 }

--- a/plugins/ca-common/tests/ca-ensure-requirements/warm-start/all-processes-already-up/process-compose.yaml
+++ b/plugins/ca-common/tests/ca-ensure-requirements/warm-start/all-processes-already-up/process-compose.yaml
@@ -1,0 +1,23 @@
+version: "0.5"
+
+# Warm-start all-mode over a process-compose instance that was booted with
+# no target (the full `devbox services up` set): everything is already
+# satisfied, so the run is a no-op past confirming that.
+processes:
+  web-server:
+    command: python3 -m http.server 7155
+    readiness_probe:
+      exec:
+        command: curl -f http://localhost:7155
+
+  database-server:
+    command: python3 -m http.server 7165
+    readiness_probe:
+      exec:
+        command: curl -f http://localhost:7165
+
+  some-oneshot:
+    command: |
+      MARKER_DIR="${MARKER_DIR:-./.tmp}"
+      mkdir -p "$MARKER_DIR"
+      touch "$MARKER_DIR/some_oneshot.ran"

--- a/plugins/ca-common/tests/ca-ensure-requirements/warm-start/all-processes-already-up/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/warm-start/all-processes-already-up/test.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+load "../../../test_helper"
+
+setup() {
+	common_setup
+}
+
+teardown() {
+	common_teardown
+}
+
+# Pre-state: the full set booted with no target — exactly what a bare
+# `devbox services up` does. The daemons keep PC alive.
+setup_full_set_already_up() {
+	devbox_services_up_background --process-compose-file="$PCFILE"
+	for _ in {1..30}; do
+		curl --silent --fail http://localhost:7155 >/dev/null 2>&1 \
+			&& curl --silent --fail http://localhost:7165 >/dev/null 2>&1 \
+			&& return 0
+		sleep 1
+	done
+	return 1
+}
+
+@test "warm-start all-mode over a full services-up instance is a no-op success" {
+	setup_full_set_already_up
+
+	run ca-ensure-requirements --process-compose-file="$PCFILE"
+
+	assert_succeeded
+	[[ "$output" == *"All processes are ready"* ]]
+	[ -f "$MARKER_DIR/some_oneshot.ran" ]
+
+	# Warm start never touches PC lifecycle; daemons running → PC left up.
+	assert_pc_still_running
+}

--- a/plugins/ca-common/tests/ca-ensure-requirements/warm-start/all-processes-scoped-instance/process-compose.yaml
+++ b/plugins/ca-common/tests/ca-ensure-requirements/warm-start/all-processes-scoped-instance/process-compose.yaml
@@ -1,0 +1,26 @@
+version: "0.5"
+
+# Documents warm-start all-mode's scope rule. When process-compose was
+# booted with a target, the non-requested processes are reported by the
+# API as Disabled — indistinguishable from config `disabled: true` — so
+# all-mode ensures only the processes the running instance has enabled.
+# (When ca-ensure-requirements boots PC itself it always boots targetless,
+# so the cold path covers the full `devbox services up` set.)
+processes:
+  already-up-daemon:
+    command: python3 -m http.server 7155
+    readiness_probe:
+      exec:
+        command: curl -f http://localhost:7155
+
+  not-requested-daemon:
+    command: python3 -m http.server 7165
+    readiness_probe:
+      exec:
+        command: curl -f http://localhost:7165
+
+  not-requested-oneshot:
+    command: |
+      MARKER_DIR="${MARKER_DIR:-./.tmp}"
+      mkdir -p "$MARKER_DIR"
+      touch "$MARKER_DIR/not_requested_oneshot.ran"

--- a/plugins/ca-common/tests/ca-ensure-requirements/warm-start/all-processes-scoped-instance/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/warm-start/all-processes-scoped-instance/test.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+load "../../../test_helper"
+
+setup() {
+	common_setup
+}
+
+teardown() {
+	common_teardown
+}
+
+# Pre-state: PC booted with a single target, so the instance's enabled
+# scope is just already-up-daemon (the daemon keeps PC alive).
+setup_scoped_instance_running() {
+	devbox_services_up_background --process-compose-file="$PCFILE" already-up-daemon
+	for _ in {1..30}; do
+		curl --silent --fail http://localhost:7155 >/dev/null 2>&1 && return 0
+		sleep 1
+	done
+	return 1
+}
+
+@test "warm-start all-mode ensures only the processes enabled in the running instance" {
+	setup_scoped_instance_running
+
+	run ca-ensure-requirements --process-compose-file="$PCFILE"
+
+	assert_succeeded
+	[[ "$output" == *"All processes are ready"* ]]
+
+	# Processes outside the running instance's boot scope report Disabled
+	# via the API (same as config-disabled), so all-mode leaves them alone.
+	run curl --silent --fail --connect-timeout 1 http://localhost:7165
+	[ "$status" -ne 0 ]
+	[ ! -f "$MARKER_DIR/not_requested_oneshot.ran" ]
+
+	assert_pc_still_running
+}

--- a/plugins/ca-common/tests/ca-ensure-requirements/warm-start/nonexistent-target/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/warm-start/nonexistent-target/test.bats
@@ -13,7 +13,7 @@ teardown() {
 @test "warm-start with an unknown target exits non-zero and leaves process-compose running" {
 	setup_unrelated_daemon_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" no-such-target
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=no-such-target
 
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"no-such-target"* ]]

--- a/plugins/ca-common/tests/ca-ensure-requirements/warm-start/pure-daemon-services-up/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/warm-start/pure-daemon-services-up/test.bats
@@ -13,7 +13,7 @@ teardown() {
 @test "pure daemon: warm-start is a no-op past confirming the graph is ready" {
 	setup_services_already_up for-verify
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" for-verify
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=for-verify
 
 	assert_succeeded
 	[[ "$output" == *"already running on port"* ]]

--- a/plugins/ca-common/tests/ca-ensure-requirements/warm-start/pure-oneshot-services-up/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/warm-start/pure-oneshot-services-up/test.bats
@@ -13,7 +13,7 @@ teardown() {
 @test "pure one-shot: warm-start is a no-op past confirming the graph is satisfied" {
 	setup_services_already_up for-verify
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" for-verify
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=for-verify
 
 	assert_succeeded
 	[[ "$output" == *"already running on port"* ]]

--- a/plugins/ca-common/tests/ca-ensure-requirements/warm-start/starts-deps-in-dependency-order/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/warm-start/starts-deps-in-dependency-order/test.bats
@@ -17,7 +17,7 @@ teardown() {
 @test "deps are started before dependents on the warm-start API path" {
 	setup_unrelated_daemon_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" for-verify
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=for-verify
 
 	assert_succeeded
 	[ -f "$MARKER_DIR/install_deps.ran" ]

--- a/plugins/ca-common/tests/ca-ensure-requirements/warm-start/unrelated-daemon-running/test.bats
+++ b/plugins/ca-common/tests/ca-ensure-requirements/warm-start/unrelated-daemon-running/test.bats
@@ -13,7 +13,7 @@ teardown() {
 @test "one-shot target succeeds when an unrelated daemon is already running" {
 	setup_unrelated_daemon_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" for-verify-oneshot
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=for-verify-oneshot
 
 	assert_succeeded
 	[ -f "$MARKER_DIR/oneshot.ran" ]
@@ -27,7 +27,7 @@ teardown() {
 @test "daemon target succeeds when an unrelated daemon is already running" {
 	setup_unrelated_daemon_running
 
-	run ca-ensure-requirements --process-compose-file="$PCFILE" for-verify-daemon
+	run ca-ensure-requirements --process-compose-file="$PCFILE" --process=for-verify-daemon
 
 	assert_succeeded
 

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -12,3 +12,8 @@ version: "0.5"
 processes:
   README:
     command: "Project all set up. You can close this window; tail -f /dev/null"
+    # Long-running processes need a readiness_probe to be verifiable by
+    # ca-ensure-requirements; this placeholder is trivially always ready.
+    readiness_probe:
+      exec:
+        command: "true"


### PR DESCRIPTION
## For reviewers

TLDR: 
 - Adds a mode to ca-ensure-requirements so can use one command for verify scripts and also for verifying project. i.e. it replaces run-with-services-up.
 - Example https://github.com/cultureamp/bef-rails-pg-demo/pull/1081 
 - This is low risk to merge as it hasn't been deployed anywhere yet. Further iteration likely to happen.

## What

`ca-ensure-requirements` now has two modes:

```
ca-ensure-requirements                  # NEW default: ensure everything devbox services up starts
ca-ensure-requirements --process=NAME   # previous behaviour: ensure NAME's dependency graph
ca-ensure-requirements NAME             # ⚠ hard error with guidance to use --process=NAME
```

The default mode runs the equivalent of `devbox services up`, waits for every process to be ready (daemons via readiness_probe) or completed with exit 0 (one-shots), and dumps the failing process's logs on error — intended as a single CI step that asserts the whole dev environment comes up green.

## How

- All-mode resolves its root set through the process-compose API: devbox merges plugin-contributed process-compose files at boot, so the API is the only accurate source of "what `devbox services up` starts". `Disabled` processes are excluded.
- Every enabled name is fed as a root into the existing multi-root `expand_dependency_graph`; the wait loop, failure reporting, and daemon-vs-oneshot lifecycle classification are unchanged. A cold-start pure-one-shot run still reaps process-compose; a graph with daemons still leaves it running.
- Cold start boots devbox with no target; warm start uses the running API and never touches PC lifecycle.

## Breaking change

The positional process name is gone. `ca-ensure-requirements <name>` exits 1 with `positional process names are no longer accepted. Use --process=<name> instead.` Update any existing callers when bumping the plugin.

## Semantics worth knowing (both encoded in tests)

- **Probe-less daemons time out.** A long-running process without a readiness_probe cannot be distinguished from a slow one-shot mid-run, so all-mode refuses to report unverifiable success. Repos using the `tail -f /dev/null` README placeholder need a trivially-true probe — this repo's root `process-compose.yaml` gets one in this PR.
- **Warm-start scope rule.** process-compose reports processes excluded by a targeted boot (`devbox services up some-name`) as `Disabled`, byte-identical to config `disabled: true` (verified empirically via both `/processes` and `/process/info`). Warm-start all-mode therefore ensures only the processes the running instance has enabled; the cold path always boots targetless and covers the full set.

## Testing

- Existing target-mode matrix (31 tests) ported to `--process=` with assertions unchanged — proving target mode's code path is behaviourally identical.
- 7 new all-mode scenarios: mixed graph (starts processes target mode would skip, PC left up), pure one-shots (PC reaped), disabled process skipped, failing process (exit 1 + logs), probe-less daemon timeout, warm-start no-op over a full instance, warm-start scope rule over a targeted instance.
- All 38 pass via `devbox run test plugins/ca-common/tests/ca-ensure-requirements`; end-to-end verified against this repo's root process-compose.yaml (cold boot, warm no-op, target mode, positional error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)