### PR TITLE
Updated debezium package url

### DIFF
--- a/packages/debezium-server.nix
+++ b/packages/debezium-server.nix
@@ -15,7 +15,15 @@ stdenv.mkDerivation {
   inherit pname version;
 
   src = fetchzip {
-    url = "https://repo1.maven.org/maven2/io/debezium/debezium-server-dist/${version}/${tarballName}";
+    # Google's Maven Central mirror first, falling back to Central itself.
+    # See: https://cloudplatform.googleblog.com/2015/11/faster-builds-for-Java-developers-with-Maven-Central-mirror.html
+    #
+    # fetchurl tries these in order and stops at the first success, so the second
+    # URL is only used if the mirror fails (e.g. 404 or connection error).
+    urls = [
+      "https://maven-central-asia.storage-download.googleapis.com/maven2/io/debezium/debezium-server-dist/${version}/${tarballName}"
+      "https://repo1.maven.org/maven2/io/debezium/debezium-server-dist/${version}/${tarballName}"
+    ];
     hash = "sha256-RiMBvg9925qcBL04XQ6mKfRg/OznvliSYGjo+HOFzJc=";
   };
 


### PR DESCRIPTION
This pull request updates the way the Debezium Server distribution is fetched in `packages/debezium-server.nix` to improve reliability and speed by introducing a mirror. The main change is to use Google’s Maven Central mirror as the primary download source, with Maven Central as a fallback.

Dependency fetching improvements:

* Updated the `src` attribute to use the `urls` list, prioritizing the Google Maven Central mirror and falling back to the main Maven Central repository if needed. This should result in faster and more reliable builds.

note:
```
maven-central-asia has faster speed:
P=maven2/io/debezium/debezium-server-dist/3.0.0.Final/debezium-server-dist-3.0.0.Final.tar.gz
for h in maven-central maven-central-eu maven-central-asia; do
  printf "%-20s " "$h"
  curl -s -r 0-20000000 -o /dev/null -w "ttfb=%{time_starttransfer}s speed=%{speed_download} B/s\n" \
    "https://$h.storage-download.googleapis.com/$P"
done
```
maven-central        ttfb=2.318928s speed=1771384 B/s
maven-central-eu     ttfb=6.068891s speed=1455846 B/s
maven-central-asia   ttfb=1.978747s speed=1838569 B/s