### PR TITLE
Fetch debezium-server via Google's Maven Central mirrors

### DIFF
--- a/packages/debezium-server.nix
+++ b/packages/debezium-server.nix
@@ -15,13 +15,14 @@ stdenv.mkDerivation {
   inherit pname version;
 
   src = fetchzip {
-    # Google's Maven Central mirror first, falling back to Central itself.
+    # Google's Maven Central mirrors (APAC, then US), falling back to Central itself.
     # See: https://cloudplatform.googleblog.com/2015/11/faster-builds-for-Java-developers-with-Maven-Central-mirror.html
     #
-    # fetchurl tries these in order and stops at the first success, so the second
-    # URL is only used if the mirror fails (e.g. 404 or connection error).
+    # fetchurl tries these in order and stops at the first success, so each URL is
+    # only used if the ones above it fail (e.g. 404 or connection error).
     urls = [
       "https://maven-central-asia.storage-download.googleapis.com/maven2/io/debezium/debezium-server-dist/${version}/${tarballName}"
+      "https://maven-central.storage-download.googleapis.com/maven2/io/debezium/debezium-server-dist/${version}/${tarballName}"
       "https://repo1.maven.org/maven2/io/debezium/debezium-server-dist/${version}/${tarballName}"
     ];
     hash = "sha256-RiMBvg9925qcBL04XQ6mKfRg/OznvliSYGjo+HOFzJc=";


### PR DESCRIPTION
## What

Fetch the `debezium-server` tarball from Google's [Maven Central mirrors](https://cloudplatform.googleblog.com/2015/11/faster-builds-for-Java-developers-with-Maven-Central-mirror.html) (APAC first, then US), keeping `repo1.maven.org` as a final fallback.

```nix
urls = [
  "https://maven-central-asia.storage-download.googleapis.com/maven2/..."
  "https://maven-central.storage-download.googleapis.com/maven2/..."
  "https://repo1.maven.org/maven2/..."
];
```

`fetchurl` tries each URL in order and stops at the first success, so a mirror being unavailable costs a retry rather than breaking the build.

## Hash unchanged

All three sources serve byte-identical tarballs (`3b3cf4b2…`, 456,940,083 bytes), and `nix-prefetch-url --unpack` against the APAC mirror reproduces the committed `sha256-RiMBvg…` exactly. No re-hashing needed, and the content-addressed store path is unchanged — anyone with the source cached is unaffected.

## Verification

- `nix build .#debezium-server` — exit 0
- `nixpkgs-fmt --check` / `statix check` — pass
- Fallback exercised with a deliberately bogus first URL: 404 on the mirror → next URL tried → success

## Worth a reviewer's opinion: the ordering

Measured from a Melbourne laptop, ranged 20MB pull of the real artifact:

| host | TTFB | speed |
|---|---|---|
| `maven-central` (US) | 3.54s | 0.82 MB/s |
| `maven-central-eu` | 6.21s | 1.18 MB/s |
| `maven-central-asia` | 1.53s | 1.64 MB/s |
| **`repo1.maven.org`** | **0.30s** | **1.95 MB/s** |

`repo1.maven.org` won because it is not a distant single origin any more — it resolves to Cloudflare (`cf-ray: …-MEL`, `cf-cache-status: HIT`), i.e. a warm edge in Melbourne. The Google mirrors are plain regional GCS buckets with no edge caching. The 2015 blog post's premise (Central is one slow far-away origin) is largely obsolete.

So on this evidence the list is close to worst-first for AU-based devs, and inverting it would use the faster path in the common case. Raising it rather than silently reordering — happy either way.

Two caveats on the redundancy: both Google URLs share DNS, TLS, and GCS, so a global GCS/googleapis failure takes out entries 1 and 2 together; `repo1` is the only genuinely independent failure domain. Also note CI never builds this package (`ci.yaml` only builds `generate-netskope-combined-cert`), so this affects developer machines, not CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)