### PR TITLE
fix: add aarch64-linux closure to bento.nix

### DIFF
--- a/packages/bento.nix
+++ b/packages/bento.nix
@@ -13,7 +13,7 @@ let
   meta = with lib; {
     description = "Fancy stream processing made operationally mundane";
     license = licenses.mit;
-    platforms = platforms.darwin;
+    platforms = platforms.darwin ++ [ "aarch64-linux" ];
   };
 in
 
@@ -37,6 +37,18 @@ else if system == "aarch64-darwin" then
     src = fetchzip {
       url = "https://github.com/warpstreamlabs/bento/releases/download/v${version}/bento_${version}_darwin_arm64.tar.gz";
       hash = "sha256-Db1u1MmPRLLcH8q4sGqr29UqJqNJf7XTNAoxU023K60=";
+      stripRoot = false;
+    };
+  }
+
+else if system == "aarch64-linux" then
+  stdenv.mkDerivation
+  {
+    inherit pname version installPhase dontStrip meta;
+
+    src = fetchzip {
+      url = "https://github.com/warpstreamlabs/bento/releases/download/v${version}/bento_${version}_linux_arm64.tar.gz";
+      hash = "sha256-jNz/LXbfwHkDdyy4EFGIbp3P2sq6fFedCU7trYryhlg=";
       stripRoot = false;
     };
   }


### PR DESCRIPTION
## Summary
- `bento.nix` only handled `x86_64-darwin`/`aarch64-darwin`; every Linux system hit `abort "unsupported system"`.
- CI agents for `agent-workflows` patch-cves run `linux_arm64`, so `devbox install` fails on every run for repos referencing `github:cultureamp/devbox-extras#bento` (`lde-kafka-sink`, and soon `delivery-eng-experiments/011-2-bento-sink`).
- Adds an `aarch64-linux` closure using the upstream `bento_1.4.0_linux_arm64.tar.gz` release asset. Verified with `nix-build` locally.

## Test plan
- [x] `nix-build -E '... import ./packages/bento.nix { system = "aarch64-linux"; ... }'` builds successfully with the new hash
- [x] `nix run nixpkgs#nixpkgs-fmt -- packages/bento.nix` reports no changes needed

Jira: FEF-3164