### PR TITLE
Use GNU gettext's envsubst in ca-kafka-local

### DIFF
--- a/plugins/ca-kafka-local/plugin.json
+++ b/plugins/ca-kafka-local/plugin.json
@@ -3,7 +3,7 @@
   "version": "0.0.3",
   "description": "Environment variables and tools to interact with `kafka-local` in your service",
   "readme": "README.md",
-  "packages": ["kafkactl@5.7.0", "kcat@1", "envsubst", "kaf"],
+  "packages": ["kafkactl@5.7.0", "kcat@1", "gettext", "kaf"],
   "env": {
     "PATH": "{{ .Virtenv }}/bin:$PATH",
     "KAFKA_BROKERS": "localhost:14231",


### PR DESCRIPTION
## Problem

`ca-kafka-local` depends on the nixpkgs `envsubst` package, which is the Go [a8m/envsubst](https://github.com/a8m/envsubst), not GNU gettext's. Devbox puts it at the front of `PATH`, so it shadows the GNU binary in every repo that includes this plugin.

Git's shell-script subcommands source GNU `gettext.sh`, which defines:

```sh
eval_gettext () {
  gettext "$1" | (export PATH `envsubst --variables "$1"`; envsubst "$1")
}
```

`git-sh-setup` calls that when it builds its usage string, so every invocation of `git mergetool`, `git request-pull`, `git merge-octopus` etc. inside an affected repo prints:

```
flag provided but not defined: -variables
Usage: envsubst [options...] <input>
Options:
  -i         Specify file input, otherwise use last argument as input file.
...
```

The Go build has no `--variables` flag. It's cosmetic — the command still runs — but it's noise on every call.

## Fix

Depend on `gettext` instead. It provides GNU `envsubst`, which the three `init_hook` lines use unchanged; the templates reference only plain `${VAR}`, so nothing needed the Go-specific `${VAR:-default}` syntax or `-no-unset`-style flags.

## Verification

Two throwaway devbox projects, identical apart from the include — one `path:`-including this branch, one including `main`:

| | `main` (`envsubst`) | this branch (`gettext`) |
| --- | --- | --- |
| `git mergetool` | flag error + usage dump | clean |
| `envsubst --variables '${FOO}'` | exit 2 | prints `FOO`, exit 0 |
| `envsubst --version` | flag error | `envsubst (GNU gettext-runtime) 1.0` |
| rendered kafkactl / kcat / kaf configs | correct | byte-identical |

No `version` bump, matching how this plugin has been changed previously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
